### PR TITLE
Use star import for @radix-ui/react-dialog

### DIFF
--- a/.changeset/nice-hats-breathe.md
+++ b/.changeset/nice-hats-breathe.md
@@ -1,0 +1,5 @@
+---
+'@markprompt/react': patch
+---
+
+Use star import for @radix-ui/react-dialog

--- a/.changeset/nice-hats-breathe.md
+++ b/.changeset/nice-hats-breathe.md
@@ -3,3 +3,8 @@
 ---
 
 Use star import for @radix-ui/react-dialog
+
+`@radix-ui/react-dialog` is [packaged incorrectly](https://github.com/radix-ui/primitives/issues/1848). Because of this, some
+tools (Next.js) must use a default import to import it, whereas others
+(Vite, Docusaurus) must use a star import. Since our demos use Vite and
+Docusaurus, let’s go with star imports.

--- a/packages/react/src/headless.tsx
+++ b/packages/react/src/headless.tsx
@@ -1,5 +1,5 @@
 import type { Options } from '@markprompt/core';
-import Dialog from '@radix-ui/react-dialog';
+import * as Dialog from '@radix-ui/react-dialog';
 import React, {
   type ComponentPropsWithoutRef,
   type ComponentPropsWithRef,


### PR DESCRIPTION
`@radix-ui/react-dialog` is packages incorrectly. Because of this, some tools (Next.js) must use a default import to import it, whereas others (Vite, Docusaurus) must use a star import. Since our demos use Vite and Docusaurus, let’s go with star imports.

See https://github.com/radix-ui/primitives/issues/1848