### PR TITLE
Ignore non-existent files in post-checkout hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-rm {examples,packages}/*/*.tsbuildinfo
+rm -f {examples,packages}/*/*.tsbuildinfo


### PR DESCRIPTION
This was causing CI to fail.