### PR TITLE
Update docs

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,1 @@
+**/CHANGELOG.md

--- a/.remarkrc.json
+++ b/.remarkrc.json
@@ -1,0 +1,13 @@
+{
+  "settings": {
+    "fences": true,
+    "listItemIndent": "one"
+  },
+  "plugins": [
+    "remark-frontmatter",
+    ["remark-prettier", { "report": false }],
+    ["remark-toc", { "tight": true }],
+    "remark-validate-links",
+    "unified-consistency"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ Markprompt is a platform for building GPT-powered prompts. It takes Markdown, Ma
 
 This repo contains various UI libraries for building prompts based on the Markprompt API:
 
-- [@markprompt/react](https://github.com/motifland/markprompt-js/blob/main/packages/react/README.md) - a headless React component
-- [@markprompt/web](https://github.com/motifland/markprompt-js/blob/main/packages/web/README.md) - a pre-built Markprompt dialog, based on `@markprompt/react`, built with Preact for bundle-size savings. Viable for use with vanilla JavaScript or any framework.
-- [@markprompt/core](https://github.com/motifland/markprompt-js/blob/main/packages/web/README.md) - shared utility functions to speak with the Markprompt API
+- [`@markprompt/core`](packages/core#readme) — shared utility functions to speak with the Markprompt API
+- [`@markprompt/docusaurus-theme-search`](packages/docusaurus-theme-search#readme) — a Markprompt search theme for Docusaurus
+- [`@markprompt/react`](packages/react#readme) — a headless React component
+- [`@markprompt/web`](packages/web#readme) — a pre-built Markprompt dialog, based on `@markprompt/react`, built with Preact for bundle-size savings. Viable for use with vanilla JavaScript or any framework.
 
 and some example implementations:
 
-- [with-css-modules](https://github.com/motifland/markprompt-js/blob/main/examples/with-css-modules/README.md) - a web application based on `@markprompt/react`, Vite and CSS Modules
-- [with-markprompt-web](https://github.com/motifland/markprompt-js/blob/main/examples/with-markprompt-web/README.md)
+- [`with-css-modules`](examples/with-css-modules#readme) — a web application based on `@markprompt/react`, Vite and CSS Modules
+- [`with-docusaurus`](examples/with-docusaurus#readme) — a Docusaurus project with `@markprompt/docusaurus-theme-search`
+- [`with-markprompt-web`](examples/with-markprompt-web#readme) — a web application based on `@markprompt/web` and Vite
+- [`with-next`](examples/with-next#readme) — a web application based on `@markprompt/react`, `@markprompt/web`, and Next.js
 
 ## Documentation
 
@@ -43,3 +46,7 @@ To use the Markprompt platform as is, please refer to the [Markprompt documentat
 
 Created by the team behind [Motif](https://motif.land)
 ([@motifland](https://twitter.com/motifland)).
+
+## License
+
+[MIT](./LICENSE) © [Motif](https://motif.land)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,13 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.0",
         "prettier-plugin-packagejson": "^2.0.0",
+        "remark-cli": "^11.0.0",
+        "remark-frontmatter": "^4.0.0",
+        "remark-prettier": "^2.0.0",
+        "remark-toc": "^8.0.0",
+        "remark-validate-links": "^12.0.0",
         "typescript": "^5.0.0",
+        "unified-consistency": "^1.0.0",
         "vitest": "^0.31.0"
       },
       "devDependencies": {
@@ -3592,6 +3598,95 @@
       "version": "1.2.1",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "license": "MIT",
@@ -4365,9 +4460,134 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/config": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-6.2.0.tgz",
+      "integrity": "sha512-lPAPNVUvlv6x0uwGiKzuWVUy1WSBaK5P0t9PoQQVIAbc1RaJLkaNxyUQZOrFJ7Y/ShzLw5skzruThhD9Qcju/A==",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^3.0.2",
+        "ini": "^4.1.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "read-package-json-fast": "^3.0.2",
+        "semver": "^7.3.5",
+        "walk-up-path": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/config/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-3.0.4.tgz",
+      "integrity": "sha512-Z0TbvXkRbacjFFLpVpV0e2mheCh+WzQpcqL+4xp49uNJOxOnIAPZyXtUxZ5Qn3QBTGKA11Exjd9a5411rBrhDg==",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^2.0.0",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0",
+        "read-package-json-fast": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/glob": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
+      "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-2.0.0.tgz",
+      "integrity": "sha512-pwK+BfEBZJbKdNYpHHRTNBwBoqrN/iIMO0AiGvYsp3Hoaq0WbgGSWQR6SCldZovoDpY3yje5lkFUe6gsDgJ2vg==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/@open-draft/until": {
       "version": "1.0.3",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@pkgr/utils": {
       "version": "2.3.1",
@@ -4941,6 +5161,14 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-t3YCerNM7NTVjLuICZo5gYAXYoDvpuuTceCcFQWcDQz26kxUR5uIWolxbIR5jRNIXpMqhOpW/b8imCR1LEmuJw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "license": "MIT",
@@ -5007,6 +5235,11 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
+    },
     "node_modules/@types/hast": {
       "version": "2.3.4",
       "license": "MIT",
@@ -5035,6 +5268,11 @@
       "dependencies": {
         "ci-info": "^3.1.0"
       }
+    },
+    "node_modules/@types/is-empty": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/is-empty/-/is-empty-1.2.1.tgz",
+      "integrity": "sha512-a3xgqnFTuNJDm1fjsTjHocYJ40Cz3t8utYpi5GNaxzrJC2HSD08ym+whIL7fNqiqBCdM9bcqD1H/tORWAFXoZw=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -5142,6 +5380,11 @@
     "node_modules/@types/parse5": {
       "version": "5.0.3",
       "license": "MIT"
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -5261,6 +5504,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw=="
+    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.6",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.6.tgz",
@@ -5269,6 +5517,11 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/text-table": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/text-table/-/text-table-0.2.2.tgz",
+      "integrity": "sha512-dGoI5Af7To0R2XE8wJuc6vwlavWARsCh3UKJPjWs1YEqGUqfgBI/j/4GX0yf19/DsDPPf0YAXWAp8psNeIehLg=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -5694,6 +5947,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "devOptional": true
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -7144,6 +7405,20 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concordance": {
       "version": "5.0.4",
@@ -9594,6 +9869,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "license": "Apache-2.0",
@@ -9977,6 +10264,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/forwarded": {
@@ -11130,6 +11425,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
+      "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "license": "MIT",
@@ -11396,6 +11700,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-empty": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+      "integrity": "sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w=="
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
@@ -11806,6 +12115,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
+      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest-diff": {
@@ -12281,6 +12607,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/levenshtein-edit-distance": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
+      "integrity": "sha512-gpgBvPn7IFIAL32f0o6Nsh2g+5uOvkt4eK9epTfgE4YVxBxwVhJ/p1888lMm/u8mXdu1ETLSi6zeEmkBI+0F3w==",
+      "bin": {
+        "levenshtein-edit-distance": "cli.js"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "license": "MIT",
@@ -12314,6 +12648,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/load-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/load-plugin/-/load-plugin-5.1.0.tgz",
+      "integrity": "sha512-Lg1CZa1CFj2CbNaxijTL6PCbzd4qGTlZov+iH2p5Xwy/ApcZJh+i6jMN2cYePouTfjJfrNu3nXFdEw8LvbjPFQ==",
+      "dependencies": {
+        "@npmcli/config": "^6.0.0",
+        "import-meta-resolve": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/load-yaml-file": {
@@ -12636,6 +12983,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
+      "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-extension-frontmatter": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-gfm": {
       "version": "2.0.2",
       "license": "MIT",
@@ -12767,8 +13128,9 @@
       }
     },
     "node_modules/mdast-util-to-string": {
-      "version": "3.1.1",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
       "dependencies": {
         "@types/mdast": "^3.0.0"
       },
@@ -12776,6 +13138,29 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdast-util-toc": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-6.1.1.tgz",
+      "integrity": "sha512-Er21728Kow8hehecK2GZtb7Ny3omcoPUVrmObiSUwmoRYVZaXLR751QROEFjR8W/vAQdHMLj49Lz20J55XaNpw==",
+      "dependencies": {
+        "@types/extend": "^3.0.0",
+        "@types/mdast": "^3.0.0",
+        "extend": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-toc/node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",
@@ -12926,6 +13311,21 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.1.tgz",
+      "integrity": "sha512-m2UH9a7n3W8VAH9JO9y01APpPKmNNNs71P0RbknEmYSaZU5Ghogv38BYO94AI5Xw6OYfxZRdHZZ2nYjs/Z+SZQ==",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -13533,6 +13933,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/minipass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mixme": {
       "version": "0.5.9",
       "license": "MIT",
@@ -13814,6 +14222,20 @@
       "version": "2.0.12",
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.1.0.tgz",
+      "integrity": "sha512-ZFPLe9Iu0tnx7oWhFxAo4s7QTn8+NNDDxYNaKLjE7Dp0tbakQ3M1QhQzsnzXHQBTUO3K9BmwaxnyO8Ayn2I95Q==",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "license": "BSD-2-Clause",
@@ -13853,6 +14275,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-all": {
@@ -14780,6 +15210,29 @@
       "version": "1.0.7",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "dependencies": {
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.2.1",
       "license": "MIT"
@@ -15601,6 +16054,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/proc-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+      "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
@@ -15645,6 +16106,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/propose": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/propose/-/propose-0.0.5.tgz",
+      "integrity": "sha512-Jary1vb+ap2DIwOGfyiadcK4x1Iu3pzpkDBy8tljFPmQvnc9ES3m1PMZOMiWOG50cfoAyYNtGeBzrp+Rlh4G9A==",
+      "dependencies": {
+        "levenshtein-edit-distance": "^1.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -16156,6 +16625,26 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/read-package-json-fast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
+      "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
+      "dependencies": {
+        "json-parse-even-better-errors": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
+      "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "license": "MIT",
@@ -16470,6 +16959,37 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.3.tgz",
+      "integrity": "sha512-bfmJW1dmR2LvaMJuAnE88pZP9DktIFYXazkTfOIKZzi3Knk9lT0roItIA24ydOucI3bV/g/tXBA6hzqq3FV9Ew==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-stringify": "^10.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-cli/-/remark-cli-11.0.0.tgz",
+      "integrity": "sha512-8JEWwArXquRq1/In4Ftz7gSG9Scwb1ijT2/dEuBETW9omqhmMRxcfjZ3iKqrak3BnCJeZSXCdWEmPhFKC8+RUQ==",
+      "dependencies": {
+        "remark": "^14.0.0",
+        "unified-args": "^10.0.0"
+      },
+      "bin": {
+        "remark": "cli.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-emoji": {
       "version": "2.2.0",
       "license": "MIT",
@@ -16515,6 +17035,21 @@
     "node_modules/remark-footnotes": {
       "version": "2.0.0",
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
+      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-frontmatter": "^1.0.0",
+        "micromark-extension-frontmatter": "^1.0.0",
+        "unified": "^10.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -16754,6 +17289,40 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-prettier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-prettier/-/remark-prettier-2.0.0.tgz",
+      "integrity": "sha512-66v8KoqnBivhcfjtahHmHU7qkQuVPq/JIsqTW8suqI8mVuHCpxjapoY2XIBLjC5J7suYICVtNRBXRwrRX7a1hA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/prettier": "^2.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "prettier-linter-helpers": "^1.0.0",
+        "vfile-location": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "prettier": "^2"
+      }
+    },
+    "node_modules/remark-prettier/node_modules/vfile-location": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+      "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-rehype": {
       "version": "10.1.0",
       "license": "MIT",
@@ -16777,6 +17346,80 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.3.tgz",
+      "integrity": "sha512-koyOzCMYoUHudypbj4XpnAKFbkddRMYZHwghnxd7ue5210WzGw6kOBwauJTRUMq16jsovXx8dYNvSSWP89kZ3A==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-toc": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-8.0.1.tgz",
+      "integrity": "sha512-7he2VOm/cy13zilnOTZcyAoyoolV26ULlon6XyCFU+vG54Z/LWJnwphj/xKIDLOt66QmJUgTyUvLVHi2aAElyg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-toc": "^6.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-validate-links": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/remark-validate-links/-/remark-validate-links-12.1.1.tgz",
+      "integrity": "sha512-nk/CkcZ3u8QntoMCqZ+JzUzFub36E+mNFMMbYqqN+yQViUHbRLqirCG1qOI4E38RyKZ8abjFUv0JGB7skKa41A==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hosted-git-info": "^6.0.0",
+        "mdast-util-to-string": "^3.2.0",
+        "propose": "0.0.5",
+        "to-vfile": "^7.0.0",
+        "trough": "^2.0.0",
+        "unified": "^10.0.0",
+        "unified-engine": "^10.0.1",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-validate-links/node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
+    },
+    "node_modules/remark-validate-links/node_modules/hosted-git-info": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/remark-validate-links/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/renderkid": {
@@ -17853,6 +18496,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.8",
       "license": "MIT",
@@ -17924,6 +18581,18 @@
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -18359,6 +19028,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-vfile": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.4.tgz",
+      "integrity": "sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==",
+      "dependencies": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^5.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "license": "MIT",
@@ -18552,6 +19234,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "license": "MIT",
@@ -18665,6 +19352,191 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unified-args": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/unified-args/-/unified-args-10.0.0.tgz",
+      "integrity": "sha512-PqsqxwkXpGSLiMkbjNnKU33Ffm6gso6rAvz1TlBGzMBx3gpx7ewIhViBX8HEWmy0v7pebA5PM6RkRWWaYmtfYw==",
+      "dependencies": {
+        "@types/text-table": "^0.2.0",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.0",
+        "chokidar": "^3.0.0",
+        "fault": "^2.0.0",
+        "json5": "^2.0.0",
+        "minimist": "^1.0.0",
+        "text-table": "^0.2.0",
+        "unified-engine": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified-args/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified-args/node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/unified-args/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/unified-consistency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unified-consistency/-/unified-consistency-1.0.0.tgz",
+      "integrity": "sha512-abPO2WeXK6vFW1OwK7wS7MVqEydq93YCS7iDWIs9l3tYblVODX01blIm8A5GSSyunk+W9M5eFWTo9ZzJqeZHpA==",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "unified": "^10.0.0",
+        "vfile-location": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/unified-consistency/node_modules/vfile-location": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+      "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified-engine": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/unified-engine/-/unified-engine-10.1.0.tgz",
+      "integrity": "sha512-5+JDIs4hqKfHnJcVCxTid1yBoI/++FfF/1PFdSMpaftZZZY+qg2JFruRbf7PaIwa9KgLotXQV3gSjtY0IdcFGQ==",
+      "dependencies": {
+        "@types/concat-stream": "^2.0.0",
+        "@types/debug": "^4.0.0",
+        "@types/is-empty": "^1.0.0",
+        "@types/node": "^18.0.0",
+        "@types/unist": "^2.0.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.0.0",
+        "fault": "^2.0.0",
+        "glob": "^8.0.0",
+        "ignore": "^5.0.0",
+        "is-buffer": "^2.0.0",
+        "is-empty": "^1.0.0",
+        "is-plain-obj": "^4.0.0",
+        "load-plugin": "^5.0.0",
+        "parse-json": "^6.0.0",
+        "to-vfile": "^7.0.0",
+        "trough": "^2.0.0",
+        "unist-util-inspect": "^7.0.0",
+        "vfile-message": "^3.0.0",
+        "vfile-reporter": "^7.0.0",
+        "vfile-statistics": "^2.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified-engine/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/unified-engine/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/unified-engine/node_modules/lines-and-columns": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
+      "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/unified-engine/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/unified-engine/node_modules/parse-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-6.0.2.tgz",
+      "integrity": "sha512-SA5aMiaIjXkAiBrW/yPgLgQAQg42f7K3ACO+2l/zOvtQBwX58DMUsFJXelW2fx3yMBmWOVkR6j1MGsdSbCA4UA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "lines-and-columns": "^2.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified-engine/node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "license": "MIT",
@@ -18686,6 +19558,18 @@
     "node_modules/unist-util-generated": {
       "version": "2.0.1",
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-inspect": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-7.0.2.tgz",
+      "integrity": "sha512-Op0XnmHUl6C2zo/yJCwhXQSm/SmW22eDZdWP2qdf4WpGrgO1ZxFodq+5zFyeRGasFjJotAnLgfuD1jkcKqiH1Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -19230,6 +20114,108 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-reporter": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-7.0.5.tgz",
+      "integrity": "sha512-NdWWXkv6gcd7AZMvDomlQbK3MqFWL1RlGzMn++/O2TI+68+nqxCPTvLugdOtfSzXmjh+xUyhp07HhlrbJjT+mw==",
+      "dependencies": {
+        "@types/supports-color": "^8.0.0",
+        "string-width": "^5.0.0",
+        "supports-color": "^9.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0",
+        "vfile-sort": "^3.0.0",
+        "vfile-statistics": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-reporter/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/vfile-reporter/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/vfile-reporter/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vfile-reporter/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vfile-reporter/node_modules/supports-color": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.3.1.tgz",
+      "integrity": "sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/vfile-sort": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-3.0.1.tgz",
+      "integrity": "sha512-1os1733XY6y0D5x0ugqSeaVJm9lYgj0j5qdcZQFyxlZOSy1jYarL77lLyb5gK4Wqr1d5OxmuyflSO3zKyFnTFw==",
+      "dependencies": {
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-statistics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-2.0.1.tgz",
+      "integrity": "sha512-W6dkECZmP32EG/l+dp2jCLdYzmnDBIw6jwiLZSER81oR5AHRcVqL+k3Z+pfH1R73le6ayDkJRMk0sutj1bMVeg==",
+      "dependencies": {
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vite": {
       "version": "4.2.1",
       "license": "MIT",
@@ -19402,6 +20388,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/walk-up-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
+      "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -20039,6 +21030,23 @@
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   ],
   "scripts": {
     "build": "npm pack --workspaces",
-    "lint": "run-p lint:format lint:js lint:ts",
+    "lint": "run-p lint:format lint:js lint:md lint:ts",
     "lint:format": "prettier --check .",
     "lint:js": "eslint . --quiet",
+    "lint:md": "remark . --frail",
     "lint:ts": "npm run build",
     "prepare": "husky install",
     "publish": "npm run build && changeset publish",
@@ -33,7 +34,13 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.0",
     "prettier-plugin-packagejson": "^2.0.0",
+    "remark-cli": "^11.0.0",
+    "remark-frontmatter": "^4.0.0",
+    "remark-prettier": "^2.0.0",
+    "remark-toc": "^8.0.0",
+    "remark-validate-links": "^12.0.0",
     "typescript": "^5.0.0",
+    "unified-consistency": "^1.0.0",
     "vitest": "^0.31.0"
   },
   "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,6 +4,32 @@
 
 It contains core functionality for Markprompt and allows you to build abstractions on top of it.
 
+<br />
+<p align="center">
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/@markprompt/core">
+    <img alt="" src="https://badgen.net/npm/v/@markprompt/core">
+  </a>
+  <a aria-label="License" href="https://github.com/motifland/markprompt-js/blob/main/packages/core/LICENSE">
+    <img alt="" src="https://badgen.net/npm/license/@markprompt/core">
+  </a>
+  <a aria-label="Coverage" href="https://app.codecov.io/gh/motifland/markprompt-js/tree/main/packages%2Fcore">
+    <img alt="" src="https://codecov.io/gh/motifland/markprompt-js/branch/main/graph/badge.svg" />
+  </a>
+</p>
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [API](#api)
+  - [`submitPrompt(prompt, projectKey, onAnswerChunk, onReferences, onError, options?)`](#submitpromptprompt-projectkey-onanswerchunk-onreferences-onerror-options)
+    - [Arguments](#arguments)
+    - [Options](#options)
+    - [Returns](#returns)
+- [Community](#community)
+- [Authors](#authors)
+- [License](#license)
+
 ## Installation
 
 ```sh
@@ -18,7 +44,7 @@ In browsers with [esm.sh](https://esm.sh):
 </script>
 ```
 
-# Usage
+## Usage
 
 ```js
 import { submitPrompt } from '@markprompt/core';
@@ -53,3 +79,52 @@ const options = {
 
 await submitPrompt(prompt, projectKey, onAnswerChunk, onReferences, onError, options);
 ```
+
+## API
+
+### `submitPrompt(prompt, projectKey, onAnswerChunk, onReferences, onError, options?)`
+
+Submit a prompt the the Markprompt API.
+
+#### Arguments
+
+- `prompt` (`string`): Prompt to submit to the model
+- `projectKey` (`string`): The key of your project
+- `onAnswerChunk` (`function`): Answers come in via streaming. This function is called when a new chunk arrives
+- `onReferences` (`function`): This function is called when a chunk includes references.
+- `onError` (`function`): called when an error occurs
+- [`options`](#options) (`object`): Optional options object
+
+#### Options
+
+- `completionsUrl` (`string`): URL at which to fetch completions
+- `iDontKnowMessage` (`string`): Message returned when the model does not have an answer
+- `model` (`OpenAIModelId`): The OpenAI model to use
+- `promptTemplate` (`string`): The prompt template
+- `temperature` (`number`): The model temperature
+- `topP` (`number`): The model top P
+- `frequencyPenalty` (`number`): The model frequency penalty
+- `presencePenalty` (`number`): The model present penalty
+- `maxTokens` (`number`): The max number of tokens to include in the response
+- `sectionsMatchCount` (`number`): The number of sections to include in the prompt context
+- `sectionsMatchThreshold` (`number`): The similarity threshold between the input question and selected sections
+- `signal` (`AbortSignal`): AbortController signal
+
+#### Returns
+
+A promise that resolves when the response is fully handled.
+
+## Community
+
+- [Twitter @markprompt](https://twitter.com/markprompt)
+- [Twitter @motifland](https://twitter.com/motifland)
+- [Discord](https://discord.gg/MBMh4apz6X)
+
+## Authors
+
+This library is created by the team behind [Motif](https://motif.land)
+([@motifland](https://twitter.com/motifland)).
+
+## License
+
+[MIT](./LICENSE) © [Motif](https://motif.land)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,12 +56,14 @@ export const DEFAULT_SECTIONS_MATCH_COUNT = 10;
 export const DEFAULT_SECTIONS_MATCH_THRESHOLD = 0.5;
 
 /**
- * @param {string} prompt - Prompt to submit to the model
- * @param {string} projectKey - The key of your project
- * @param {(answerChunk: string) => void} onAnswerChunk - Answers come in via streaming. This function is called when a new chunk arrives
- * @param {(references: string[]) => void} onReferences - This function is called when a chunk includes references.
- * @param {(error: Error) => void} onError - called when an error occurs
- * @param {Options} [options] - Optional options object
+ * Submit a prompt the the Markprompt API.
+ *
+ * @param prompt - Prompt to submit to the model
+ * @param projectKey - The key of your project
+ * @param onAnswerChunk - Answers come in via streaming. This function is called when a new chunk arrives
+ * @param onReferences - This function is called when a chunk includes references.
+ * @param onError - called when an error occurs
+ * @param [options] - Optional options object
  */
 export async function submitPrompt(
   prompt: string,

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,0 +1,108 @@
+# `@markprompt/css`
+
+Common CSS for [Markprompt](https://markprompt.com) components.
+
+<br />
+<p align="center">
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/@markprompt/css">
+    <img alt="" src="https://badgen.net/npm/v/@markprompt/css">
+  </a>
+  <a aria-label="License" href="https://github.com/motifland/markprompt-js/blob/main/packages/css/LICENSE">
+    <img alt="" src="https://badgen.net/npm/license/@markprompt/css">
+  </a>
+</p>
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [API](#api)
+  - [CSS Classes](#css-classes)
+  - [CSS Variables](#css-variables)
+- [Community](#community)
+- [Authors](#authors)
+- [License](#license)
+
+## Installation
+
+```sh
+npm install @markprompt/core
+```
+
+## Usage
+
+With a bundler:
+
+```js
+import '@markprompt/css';
+```
+
+With a CDN:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@markprompt/css@0.1.0/markprompt.css"
+/>
+```
+
+This package adds styling for various CSS classes. All styling is applied using the [`:where()`](https://developer.mozilla.org/en-US/docs/Web/CSS/:where) pseudo class, so you can override all styling manually.
+
+## API
+
+### CSS Classes
+
+The package adds styling using the following classes.
+
+- `MarkpromptAnswer`
+- `MarkpromptAutoScroller`
+- `MarkpromptCaret`
+- `MarkpromptClose`
+- `MarkpromptContent`
+- `MarkpromptForm`
+- `MarkpromptIcon`
+- `MarkpromptOverlay`
+- `MarkpromptProgress`
+- `MarkpromptPrompt`
+- `MarkpromptPromptLabel`
+- `MarkpromptReferences`
+- `MarkpromptSearchIcon`
+- `MarkpromptTitle`
+- `MarkpromptTrigger`
+
+### CSS Variables
+
+Styling can be customized using the following CSS variables.
+
+- `--markprompt-background`: (Default: `#ffffff`, Default dark: `#050505`)
+- `--markprompt-foreground`: (Default: `#171717`, Default dark: `#d4d4d4`)
+- `--markprompt-muted`: (Default: `#fafafa`, Default dark: `#171717`)
+- `--markprompt-mutedForeground`: (Default: `#737373`, Default dark: `#737373`)
+- `--markprompt-border`: (Default: `#e5e5e5`, Default dark: `#262626`)
+- `--markprompt-input`: (Default: `#ffffff`, Default dark: `#ffffff`)
+- `--markprompt-primary`: (Default: `#6366f1`, Default dark: `#6366f1`)
+- `--markprompt-primaryForeground`: (Default: `#ffffff`, Default dark: `#ffffff`)
+- `--markprompt-secondary`: (Default: `#fafafa`, Default dark: `#0e0e0e`)
+- `--markprompt-secondaryForeground`: (Default: `#171717`, Default dark: `#ffffff`)
+- `--markprompt-primaryHighlight`: (Default: `#ec4899`, Default dark: `#ec4899`)
+- `--markprompt-secondaryHighlight`: (Default: `#a855f7`, Default dark: `#a855f7`)
+- `--markprompt-overlay`: (Default: `#00000010`, Default dark: `#00000040\`)
+- `--markprompt-ring`: (Default: `#0ea5e9`, Default dark: `#ffffff`)
+- `--markprompt-radius`: (Default: `8px`)
+- `--markprompt-text-size`-(Default: `0.875rem`)
+- `--markprompt-button-icon-size`-(Default: `: 1rem`)
+
+## Community
+
+- [Twitter @markprompt](https://twitter.com/markprompt)
+- [Twitter @motifland](https://twitter.com/motifland)
+- [Discord](https://discord.gg/MBMh4apz6X)
+
+## Authors
+
+This library is created by the team behind [Motif](https://motif.land)
+([@motifland](https://twitter.com/motifland)).
+
+## License
+
+[MIT](./LICENSE) © [Motif](https://motif.land)

--- a/packages/docusaurus-theme-search/LICENSE
+++ b/packages/docusaurus-theme-search/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Motif
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/docusaurus-theme-search/README.md
+++ b/packages/docusaurus-theme-search/README.md
@@ -19,6 +19,8 @@ A [Markprompt](https://markprompt.com) button for [Docusaurus](https://docusauru
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Basic Usage](#basic-usage)
+  - [Swizzling](#swizzling)
 - [Example](#example)
 - [Community](#community)
 - [Authors](#authors)
@@ -31,6 +33,8 @@ npm install @markprompt/docusaurus-theme-search
 ```
 
 ## Usage
+
+### Basic Usage
 
 In your `docusaurus.config.js`, add `@markprompt/docusaurus-theme-search` to `themes`. Configure `markprompt` in the `themeConfig`.
 
@@ -53,6 +57,30 @@ const config = {
 ```
 
 Now a search button will appears on your docusaurus page.
+
+### Swizzling
+
+The MarkPrompt `SearchBar` can be swizzled. This allows you to fully customize the prompt. To swizzle, run:
+
+```js
+docusaurus swizzle '@markprompt/docusaurus-theme-search' SearchBar --typescript
+```
+
+This is useful for example if you want to add another search provider in addition to Markprompt. Typically you will want to wrap `<Markprompt.Root>` in a fragment and add your custom search provider.
+
+```tsx
+export default function SearchBar() {
+  const { siteConfig } = useDocusaurusContext();
+  const markpromptConfig = siteConfig.themeConfig.markprompt;
+
+  return (
+    <>
+      <YourSearchComponent />
+      <Markprompt.Root {...markpromptConfig}>
+    </>
+  )
+}
+```
 
 ## Example
 

--- a/packages/docusaurus-theme-search/README.md
+++ b/packages/docusaurus-theme-search/README.md
@@ -1,27 +1,33 @@
-# Markprompt React
+# `@markprompt/docusaurus-theme-search`
 
 A [Markprompt](https://markprompt.com) button for [Docusaurus](https://docusaurus.io).
 
 <br />
 <p align="center">
-  <a aria-label="NPM version" href="https://www.npmjs.com/package/markprompt">
-    <img alt="" src="https://badgen.net/npm/v/markprompt">
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/@markprompt/docusaurus-theme-search">
+    <img alt="" src="https://badgen.net/npm/v/@markprompt/docusaurus-theme-search">
   </a>
-  <a aria-label="License" href="https://github.com/motifland/markprompt/blob/main/LICENSE">
-    <img alt="" src="https://badgen.net/npm/license/markprompt">
+  <a aria-label="License" href="https://github.com/motifland/markprompt-js/blob/main/packages/docusaurus-theme-search/LICENSE">
+    <img alt="" src="https://badgen.net/npm/license/@markprompt/docusaurus-theme-search">
+  </a>
+  <a aria-label="Coverage" href="https://app.codecov.io/gh/motifland/markprompt-js/tree/main/packages%2Fdocusaurus-theme-search">
+    <img alt="" src="https://codecov.io/gh/motifland/markprompt-js/branch/main/graph/badge.svg" />
   </a>
 </p>
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Example](#example)
+- [Community](#community)
+- [Authors](#authors)
+- [License](#license)
+
 ## Installation
 
-Install the `@markprompt/docusaurus-theme-search` package via npm or yarn:
-
 ```sh
-# npm
 npm install @markprompt/docusaurus-theme-search
-
-# Yarn
-yarn add @markprompt/docusaurus-theme-search
 ```
 
 ## Usage
@@ -62,3 +68,7 @@ An example is available on <https://github.com/motifland/markprompt-js/tree/main
 
 This library is created by the team behind [Motif](https://motif.land)
 ([@motifland](https://twitter.com/motifland)).
+
+## License
+
+[MIT](./LICENSE) © [Motif](https://motif.land)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,8 +7,11 @@ The [Markprompt](https://markprompt.com) React component is a headless component
   <a aria-label="NPM version" href="https://www.npmjs.com/package/@markprompt/react">
     <img alt="" src="https://badgen.net/npm/v/@markprompt/react">
   </a>
-  <a aria-label="License" href="https://github.com/motifland/markprompt-js/blob/main/LICENSE">
+  <a aria-label="License" href="https://github.com/motifland/markprompt-js/blob/main/packages/react/LICENSE">
     <img alt="" src="https://badgen.net/npm/license/@markprompt/react">
+  </a>
+  <a aria-label="Coverage" href="https://app.codecov.io/gh/motifland/markprompt-js/tree/main/packages%2Freact">
+    <img alt="" src="https://codecov.io/gh/motifland/markprompt-js/branch/main/graph/badge.svg" />
   </a>
 </p>
 
@@ -141,6 +144,81 @@ const References = () => {
 
 replacing `<projectKey>` with the key associated to your project. It can be obtained in the project settings under "Project key".
 
+## API
+
+### `<Answer />`
+
+Render the markdown answer from the Markprompt API. It accepts the same props as [`react-markdown`](https://github.com/remarkjs/react-markdown#props), except `children`.
+
+### `<AutoScroller />`
+
+A component automatically that scrolls to the bottom. It accepts the following props:
+
+- `autoScroll` (`boolean`): Whether or not to enable automatic scrolling. (Default: `true`)
+- `scrollBehaviour` (`string`): The behaviour to use for scrolling. (Default: `smooth`)
+
+All other props will be passed to the underlying `<div>` element.
+
+### `<Close />`
+
+A button to close the Markprompt dialog and abort an ongoing request. It accepts the same props as [Radix UI `Dialog.Close`](https://www.radix-ui.com/docs/primitives/components/dialog#close).
+
+### `<Content />`
+
+The Markprompt dialog content. It accepts the same props as [Radix UI `Dialog.Content`](https://www.radix-ui.com/docs/primitives/components/dialog#content), with the following additional prop:
+
+- `showBranding` (`boolean`): Show the Markprompt footer.
+
+### `<Description />`
+
+A visually hidden aria description. It accepts the same props as [Radix UI `Dialog.Description`](https://www.radix-ui.com/docs/primitives/components/dialog#description), with the following additional prop:
+
+- `hide` (`boolean`): Hide the description.
+
+### `<Form />`
+
+A form which, when submitted, submits the current prompt. It accepts the same props as `<form>`.
+
+### `<Overlay />`
+
+The Markprompt dialog overlay. It accepts the same props as [Radix UI `Dialog.Overlay`](https://www.radix-ui.com/docs/primitives/components/dialog#overlay).
+
+### `<Portal />`
+
+The Markprompt dialog portal. It accepts the same props as [Radix UI `Dialog.Portal`](https://www.radix-ui.com/docs/primitives/components/dialog#portal).
+
+### `<Prompt />`
+
+The Markprompt input prompt. User input will update the prompt in the Markprompt context. It accepts the following props:
+
+- `label` (`ReactNode`): The label for the input.
+- `labelClassName` (`string`): The class name of the label element.
+
+### `<References />`
+
+Render the references that Markprompt returns. It accepts the following props:
+
+- `RootComponent` (`Component`): The wrapper component to render. (Default: `'ul'`)
+- `ReferenceComponent` (`Component`): The component to render for each reference. (Default: '`li`')
+
+### `<Root />`
+
+The Markprompt context provider and dialog root. It accepts the [Radix UI `Dialog.Root`](https://www.radix-ui.com/docs/primitives/components/dialog#root) props and the `useMarkprompt`options as props.
+
+### `<Title />`
+
+A visually hidden aria title. It accepts the same props as [Radix UI `Dialog.Title`](https://www.radix-ui.com/docs/primitives/components/dialog#title), with the following additional prop:
+
+- `hide` (`boolean`): Hide the title.
+
+### `<Trigger />`
+
+A button to open the Markprompt dialog. It accepts the same props as [Radix UI `Dialog.Trigger`](https://www.radix-ui.com/docs/primitives/components/dialog#trigger).
+
+### `useMarkprompt(options)`
+
+Create an interactive stateful Markprompt prompt. It takes the same options as [`submitPrompt()`](https://github.com/motifland/markprompt-js/tree/main/packages/core#options), and the project key.
+
 ## Documentation
 
 The full documentation for the component can be found on the [Markprompt docs](https://markprompt.com/docs#react).
@@ -159,3 +237,7 @@ For a working setup based on Next.js + Tailwind, check out the [Markprompt start
 
 This library is created by the team behind [Motif](https://motif.land)
 ([@motifland](https://twitter.com/motifland)).
+
+## License
+
+[MIT](./LICENSE) © [Motif](https://motif.land)

--- a/packages/react/src/headless.tsx
+++ b/packages/react/src/headless.tsx
@@ -1,4 +1,3 @@
-import type { Options } from '@markprompt/core';
 import * as Dialog from '@radix-ui/react-dialog';
 import React, {
   forwardRef,
@@ -10,7 +9,6 @@ import React, {
   type ComponentPropsWithoutRef,
   type ElementType,
   type FormEventHandler,
-  type MouseEvent,
   type MouseEventHandler,
   type ReactElement,
   type ReactNode,
@@ -23,13 +21,16 @@ import { ConditionalVisuallyHidden } from './ConditionalWrap.js';
 import { MarkpromptContext, useMarkpromptContext } from './context.js';
 import { Footer } from './footer.js';
 import type { PolymorphicRef } from './types.js';
-import { useMarkprompt } from './useMarkprompt.js';
+import { useMarkprompt, type UseMarkpromptOptions } from './useMarkprompt.js';
 
-export type RootProps = ComponentPropsWithoutRef<typeof Dialog.Root> & {
-  children: ReactNode;
-  projectKey: string;
-} & Options;
+type RootProps = ComponentPropsWithoutRef<typeof Dialog.Root> &
+  UseMarkpromptOptions & {
+    children: ReactNode;
+  };
 
+/**
+ * The Markprompt context provider and dialog root.
+ */
 function Root(props: RootProps): ReactElement {
   const {
     children,
@@ -76,33 +77,43 @@ function DialogRootWithAbort(props: Dialog.DialogProps): ReactElement {
   );
 }
 
-const Trigger = forwardRef<
-  HTMLButtonElement,
-  ComponentPropsWithRef<typeof Dialog.Trigger>
->((props, ref) => {
+type TriggerProps = ComponentPropsWithRef<typeof Dialog.Trigger>;
+/**
+ * A button to open the Markprompt dialog.
+ */
+const Trigger = forwardRef<HTMLButtonElement, TriggerProps>((props, ref) => {
   return <Dialog.Trigger ref={ref} {...props} />;
 });
 Trigger.displayName = 'Markprompt.Trigger';
 
-function Portal(
-  props: ComponentPropsWithoutRef<typeof Dialog.Portal>,
-): ReactElement {
+type PortalProps = ComponentPropsWithoutRef<typeof Dialog.Portal>;
+/**
+ * The Markprompt dialog portal.
+ */
+function Portal(props: PortalProps): ReactElement {
   return <Dialog.Portal {...props} />;
 }
 Portal.displayName = 'Markprompt.Portal';
 
-const Overlay = forwardRef<
-  HTMLDivElement,
-  ComponentPropsWithRef<typeof Dialog.Overlay>
->((props, ref) => {
+type OverlayProps = ComponentPropsWithRef<typeof Dialog.Overlay>;
+/**
+ * The Markprompt dialog overlay.
+ */
+const Overlay = forwardRef<HTMLDivElement, OverlayProps>((props, ref) => {
   return <Dialog.Overlay ref={ref} {...props} />;
 });
 Overlay.displayName = 'Markprompt.Overlay';
 
 type ContentProps = ComponentPropsWithRef<typeof Dialog.Content> & {
+  /**
+   * Show the Markprompt footer.
+   */
   showBranding?: boolean;
 };
 
+/**
+ * The Markprompt dialog content.
+ */
 const Content = forwardRef<HTMLDivElement, ContentProps>(function Content(
   props,
   ref,
@@ -119,11 +130,12 @@ const Content = forwardRef<HTMLDivElement, ContentProps>(function Content(
 });
 Content.displayName = 'Markprompt.Content';
 
-type CloseProps = ComponentPropsWithRef<typeof Dialog.Close> & {
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-};
+type CloseProps = ComponentPropsWithRef<typeof Dialog.Close>;
+/**
+ * A button to close the Markprompt dialog and abort an ongoing request.
+ */
 const Close = forwardRef<HTMLButtonElement, CloseProps>(function Close(
-  props: CloseProps,
+  props,
   ref,
 ) {
   const { onClick, ...rest } = props;
@@ -159,6 +171,9 @@ Title.displayName = 'Markprompt.Title';
 type DescriptionProps = ComponentPropsWithRef<typeof Dialog.Description> & {
   hide?: boolean;
 };
+/**
+ * A visually hidden aria description.
+ */
 const Description = forwardRef<HTMLParagraphElement, DescriptionProps>(
   (props, ref) => {
     const { hide } = props;
@@ -172,6 +187,9 @@ const Description = forwardRef<HTMLParagraphElement, DescriptionProps>(
 Description.displayName = 'Markprompt.Description';
 
 type FormProps = ComponentPropsWithRef<'form'>;
+/**
+ * A form which, when submitted, submits the current prompt.
+ */
 const Form = forwardRef<HTMLFormElement, FormProps>(function Form(props, ref) {
   const { onSubmit, ...rest } = props;
   const { submit } = useMarkpromptContext();
@@ -190,9 +208,14 @@ const Form = forwardRef<HTMLFormElement, FormProps>(function Form(props, ref) {
 Form.displayName = 'Markprompt.Form';
 
 type PromptProps = ComponentPropsWithRef<'input'> & {
+  /** The label for the input. */
   label?: ReactNode;
+  /** The class name of the label element. */
   labelClassName?: string;
 };
+/**
+ * The Markprompt input prompt. User input will update the prompt in the Markprompt context.
+ */
 const Prompt = forwardRef<HTMLInputElement, PromptProps>(function Prompt(
   props,
   ref,
@@ -247,6 +270,9 @@ const Prompt = forwardRef<HTMLInputElement, PromptProps>(function Prompt(
 Prompt.displayName = 'Markprompt.Prompt';
 
 type AnswerProps = Omit<ComponentPropsWithoutRef<typeof Markdown>, 'children'>;
+/**
+ * Render the markdown answer from the Markprompt API.
+ */
 function Answer(props: AnswerProps): ReactElement {
   const { remarkPlugins = [remarkGfm], ...rest } = props;
   const { answer } = useMarkpromptContext();
@@ -259,9 +285,23 @@ function Answer(props: AnswerProps): ReactElement {
 Answer.displayName = 'Markprompt.Answer';
 
 type AutoScrollerProps = ComponentPropsWithRef<'div'> & {
+  /**
+   * Whether or not to enable automatic scrolling.
+   *
+   * @default true
+   */
   autoScroll?: boolean;
+
+  /**
+   * The behaviour to use for scrolling.
+   *
+   * @default 'smooth'
+   */
   scrollBehavior?: ScrollBehavior;
 };
+/**
+ * A component automatically that scrolls to the bottom.
+ */
 const AutoScroller = forwardRef<HTMLDivElement, AutoScrollerProps>(
   (props, ref) => {
     const { autoScroll = true, scrollBehavior = 'smooth' } = props;
@@ -289,10 +329,22 @@ type ReferencesProps<
     index: number;
   }>,
 > = {
+  /**
+   * The wrapper component to render.
+   * @default 'ul'
+   */
   RootComponent?: TRoot;
+
+  /**
+   * The component to render for each reference.
+   * @default 'li'
+   */
   ReferenceComponent?: TReference;
 };
 
+/**
+ * Render the references that Markprompt returns.
+ */
 const References = function References<
   TRoot extends ElementType,
   TReference extends ElementType<{
@@ -318,21 +370,37 @@ const References = function References<
     </RootComponent>
   );
 };
+/**
+ * Render the references that Markprompr returned.
+ */
 const ForwardedReferences = forwardRef(References);
 ForwardedReferences.displayName = 'Markprompt.References';
 
 export {
   Answer,
+  type AnswerProps,
   AutoScroller,
+  type AutoScrollerProps,
   Close,
+  type CloseProps,
   Content,
+  type ContentProps,
   Description,
+  type DescriptionProps,
   Form,
+  type FormProps,
   Overlay,
+  type OverlayProps,
   Portal,
+  type PortalProps,
   Prompt,
+  type PromptProps,
   ForwardedReferences as References,
+  type ReferencesProps,
   Root,
+  type RootProps,
   Title,
+  type TitleProps,
   Trigger,
+  type TriggerProps,
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,20 +1,36 @@
-export { useMarkprompt } from './useMarkprompt.js';
+export {
+  useMarkprompt,
+  type UseMarkpromptOptions,
+  type UseMarkpromptResult,
+} from './useMarkprompt.js';
 
 export {
   Root,
   type RootProps,
   Trigger,
+  type TriggerProps,
   Portal,
+  type PortalProps,
   Overlay,
+  type OverlayProps,
   Content,
+  type ContentProps,
   Close,
+  type CloseProps,
   Title,
+  type TitleProps,
   Description,
+  type DescriptionProps,
   Form,
+  type FormProps,
   Prompt,
+  type PromptProps,
   Answer,
+  type AnswerProps,
   AutoScroller,
+  type AutoScrollerProps,
   References,
+  type ReferencesProps,
 } from './headless.js';
 
 export { useMarkpromptContext } from './context.js';

--- a/packages/react/src/useMarkprompt.tsx
+++ b/packages/react/src/useMarkprompt.tsx
@@ -51,6 +51,9 @@ export type UseMarkpromptResult = {
   submit: () => Promise<void>;
 };
 
+/**
+ * Create an interactive stateful Markprompt prompt
+ */
 export function useMarkprompt({
   projectKey,
   completionsUrl = MARKPROMPT_COMPLETIONS_URL,

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -10,7 +10,24 @@ A prebuilt version of the Markprompt dialog, based on `@markprompt/react`, built
   <a aria-label="License" href="https://github.com/motifland/markprompt/blob/main/LICENSE">
     <img alt="" src="https://badgen.net/npm/license/markprompt">
   </a>
+  <a aria-label="Coverage" href="https://app.codecov.io/gh/motifland/markprompt-js/tree/main/packages%2Fweb">
+    <img alt="" src="https://codecov.io/gh/motifland/markprompt-js/branch/main/graph/badge.svg" />
+  </a>
 </p>
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Usage via `<script>` tag](#usage-via-script-tag)
+- [API](#api)
+  - [`markprompt(projectKey, container, options?)`](#markpromptprojectkey-container-options)
+    - [Arguments](#arguments)
+    - [Options](#options)
+- [Documentation](#documentation)
+- [Community](#community)
+- [Authors](#authors)
+- [License](#license)
 
 ## Installation
 
@@ -132,6 +149,45 @@ Besides initializing the Markprompt component yourselves from JavaScript, you ca
 ></script>
 ```
 
+## API
+
+### `markprompt(projectKey, container, options?)`
+
+Render a markprompt dialog button.
+
+#### Arguments
+
+- `projectKey` (`string`): Your Markprompt project key.
+- `container` (`HTMLElement | string`): The element or selector to render Markprompt into.
+- `options` (`object`): Options for customizing Markprompt.
+
+#### Options
+
+- `completionsUrl` (`string`): URL at which to fetch completions
+- `iDontKnowMessage` (`string`): Message returned when the model does not have an answer
+- `model` (`OpenAIModelId`): The OpenAI model to use
+- `promptTemplate` (`string`): The prompt template
+- `temperature` (`number`): The model temperature
+- `topP` (`number`): The model top P
+- `frequencyPenalty` (`number`): The model frequency penalty
+- `presencePenalty` (`number`): The model present penalty
+- `maxTokens` (`number`): The max number of tokens to include in the response
+- `sectionsMatchCount` (`number`): The number of sections to include in the prompt context
+- `sectionsMatchThreshold` (`number`): The similarity threshold between the input question and selected sections
+- `signal` (`AbortSignal`): AbortController signal
+- `close.label` (`string`): `aria-label` for the close modal button. (Default: `"Close Markprompt"`)
+- `decription.hide` (`boolean`): Visually hide the description. (Default `true`)
+- `decription.text` (`string`): Description text.
+- `prompt.label` )`string`): Label for the prompt input. (Default `"Your prompt"`)
+- `prompt.placeholder` )`string`): Placeholder for the prompt input. (Default `"Ask me anything…"`)
+- `references.transformReferenceId` (`Function`): Callback to transform a reference id into an href and text.
+- `references.loadingText` (`string`) Loading text. (Default: `Fetching relevant pages…`)
+- `references.referencesText` (`string`): References title. (Default: `"Answer generated from the following sources:"`)
+- `trigger.label` (`string`): `aria-label` for the open button. (Default: `"Open Markprompt"`)
+- `title.hide` (`boolean`): Visually hide the title. (Default: `true`)
+- `title.text` (`string`): Text for the title. (Default: `"Ask me anything"`)
+- `showBranding` (`boolean`): Show Markprompt branding. (Default: `true`)
+
 ## Documentation
 
 The full documentation for `@markprompt/web` can be found on the [Markprompt docs](https://markprompt.com/docs#%40markprompt%2Fweb).
@@ -146,3 +202,7 @@ The full documentation for `@markprompt/web` can be found on the [Markprompt doc
 
 This library is created by the team behind [Motif](https://motif.land)
 ([@motifland](https://twitter.com/motifland)).
+
+## License
+
+[MIT](./LICENSE) © [Motif](https://motif.land)

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -15,6 +15,8 @@ function getHTMLElement(
 }
 
 /**
+ * Render a markprompt dialog button.
+ *
  * @param projectKey Your Markprompt project key
  * @param container The element or selector to render Markprompt into
  * @param options Options for customizing Markprompt


### PR DESCRIPTION
- Add missing JSDoc.
- Export options and props types.
- Document all docs in the readmes.
- Add remark for some basic markdown linting.
- Add a consistent readme layout.

If we add the readme to each package’s export map, we could render it on https://markprompt.com/docs.