### PR TITLE
Add an optional search input trigger

### DIFF
--- a/.changeset/afraid-hotels-cross.md
+++ b/.changeset/afraid-hotels-cross.md
@@ -1,0 +1,5 @@
+---
+'@markprompt/docusaurus-theme-search': minor
+---
+
+Don't allow search in docusaurus-theme-search until we have a chance to update the SearchBar component

--- a/.changeset/beige-geckos-deny.md
+++ b/.changeset/beige-geckos-deny.md
@@ -1,0 +1,5 @@
+---
+'@markprompt/web': minor
+---
+
+Add a new type of trigger that has the appearance of a search input, update types and the way that we pass options into Markprompt.Root

--- a/.changeset/four-panthers-rest.md
+++ b/.changeset/four-panthers-rest.md
@@ -1,0 +1,5 @@
+---
+'@markprompt/css': minor
+---
+
+Add MarkpromptSearchBoxTrigger styles

--- a/.changeset/mighty-laws-relax.md
+++ b/.changeset/mighty-laws-relax.md
@@ -1,0 +1,5 @@
+---
+'@markprompt/react': minor
+---
+
+Update types and the way options are passed, fix a bug where a search result was clicked when Cmd/Ctrl+Enter was pressed instead of navigating to the Prompt view

--- a/examples/with-css-modules/src/App.tsx
+++ b/examples/with-css-modules/src/App.tsx
@@ -9,23 +9,25 @@ function Component(): ReactElement {
   return (
     <Markprompt.Root
       projectKey={import.meta.env.VITE_PROJECT_API_KEY}
-      iDontKnowMessage="Sorry, I am not sure how to answer that."
-      promptTemplate={`You are a very enthusiastic company representative who loves to help people! Given the following sections from the documentation (preceded by a section id), answer the question using only that information, output in Markdown format. If you are unsure and the answer is not explicitly written in the documentation, say "{{I_DONT_KNOW}}".
+      promptOptions={{
+        iDontKnowMessage: 'Sorry, I am not sure how to answer that.',
+        promptTemplate: `You are a very enthusiastic company representative who loves to help people! Given the following sections from the documentation (preceded by a section id), answer the question using only that information, output in Markdown format. If you are unsure and the answer is not explicitly written in the documentation, say "{{I_DONT_KNOW}}".
 
-Context sections:
----
-{{CONTEXT}}
+  Context sections:
+  ---
+  {{CONTEXT}}
 
-Question: "{{PROMPT}}"
+  Question: "{{PROMPT}}"
 
-Answer (including related code snippets if available):`}
-      temperature={0.1}
-      topP={1}
-      frequencyPenalty={0}
-      presencePenalty={0}
-      maxTokens={500}
-      sectionsMatchCount={10}
-      sectionsMatchThreshold={0.5}
+  Answer (including related code snippets if available):`,
+        temperature: 0.1,
+        topP: 1,
+        frequencyPenalty: 0,
+        presencePenalty: 0,
+        maxTokens: 500,
+        sectionsMatchCount: 10,
+        sectionsMatchThreshold: 0.5,
+      }}
     >
       <Markprompt.DialogTrigger
         aria-label="Open Markprompt"

--- a/examples/with-markprompt-web/index.html
+++ b/examples/with-markprompt-web/index.html
@@ -9,9 +9,11 @@
   <body>
     <div id="app">
       <main>
-        <p>Click the Markprompt button ↘️</p>
+        <div class="centered">
+          <p>Click the Markprompt button ↘️</p>
+          <div id="markprompt"></div>
+        </div>
       </main>
-      <div id="markprompt"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -6,5 +6,7 @@ import { markprompt } from '@markprompt/web';
 const el = document.querySelector('#markprompt');
 
 if (el && el instanceof HTMLElement) {
-  markprompt(import.meta.env.VITE_PROJECT_API_KEY, el);
+  markprompt(import.meta.env.VITE_PROJECT_API_KEY, el, {
+    trigger: { floating: false },
+  });
 }

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -7,6 +7,6 @@ const el = document.querySelector('#markprompt');
 
 if (el && el instanceof HTMLElement) {
   markprompt(import.meta.env.VITE_PROJECT_API_KEY, el, {
-    trigger: { floating: false },
+    trigger: { floating: true },
   });
 }

--- a/examples/with-markprompt-web/src/style.css
+++ b/examples/with-markprompt-web/src/style.css
@@ -31,3 +31,8 @@ main {
   min-height: 100vh;
   min-height: 100dvh;
 }
+
+.centered {
+  display: grid;
+  place-items: center;
+}

--- a/examples/with-next/pages/index.tsx
+++ b/examples/with-next/pages/index.tsx
@@ -10,23 +10,25 @@ function IndexPage(): ReactElement {
   return (
     <Markprompt.Root
       projectKey={process.env.MARKPROMPT_PROJECT_KEY!}
-      iDontKnowMessage="Sorry, I am not sure how to answer that."
-      promptTemplate={`You are a very enthusiastic company representative who loves to help people! Given the following sections from the documentation (preceded by a section id), answer the question using only that information, output in Markdown format. If you are unsure and the answer is not explicitly written in the documentation, say "{{I_DONT_KNOW}}".
+      promptOptions={{
+        iDontKnowMessage: 'Sorry, I am not sure how to answer that.',
+        promptTemplate: `You are a very enthusiastic company representative who loves to help people! Given the following sections from the documentation (preceded by a section id), answer the question using only that information, output in Markdown format. If you are unsure and the answer is not explicitly written in the documentation, say "{{I_DONT_KNOW}}".
 
-Context sections:
----
-{{CONTEXT}}
+  Context sections:
+  ---
+  {{CONTEXT}}
 
-Question: "{{PROMPT}}"
+  Question: "{{PROMPT}}"
 
-Answer (including related code snippets if available):`}
-      temperature={0.1}
-      topP={1}
-      frequencyPenalty={0}
-      presencePenalty={0}
-      maxTokens={500}
-      sectionsMatchCount={10}
-      sectionsMatchThreshold={0.5}
+  Answer (including related code snippets if available):`,
+        temperature: 0.1,
+        topP: 1,
+        frequencyPenalty: 0,
+        presencePenalty: 0,
+        maxTokens: 500,
+        sectionsMatchCount: 10,
+        sectionsMatchThreshold: 0.5,
+      }}
     >
       <Markprompt.DialogTrigger
         aria-label="Open Markprompt"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,18 +16,16 @@ It contains core functionality for Markprompt and allows you to build abstractio
 
 ## Table of Contents
 
-- [`@markprompt/core`](#markpromptcore)
-  - [Table of Contents](#table-of-contents)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [API](#api)
-    - [`submitPrompt(prompt, projectKey, onAnswerChunk, onReferences, onError, options?)`](#submitpromptprompt-projectkey-onanswerchunk-onreferences-onerror-options)
-      - [Arguments](#arguments)
-      - [Options](#options)
-      - [Returns](#returns)
-  - [Community](#community)
-  - [Authors](#authors)
-  - [License](#license)
+- [Installation](#installation)
+- [Usage](#usage)
+- [API](#api)
+  - [`submitPrompt(prompt, projectKey, onAnswerChunk, onReferences, onError, options?)`](#submitpromptprompt-projectkey-onanswerchunk-onreferences-onerror-options)
+    - [Arguments](#arguments)
+    - [Options](#options)
+    - [Returns](#returns)
+- [Community](#community)
+- [Authors](#authors)
+- [License](#license)
 
 ## Installation
 

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -52,11 +52,15 @@
   box-sizing: inherit;
 }
 
-:where(.MarkpromptTrigger, .MarkpromptClose) {
+:where(
+    .MarkpromptFloatingTrigger,
+    .MarkpromptSearchBoxTrigger,
+    .MarkpromptClose
+  ) {
   all: unset;
 }
 
-:where(.MarkpromptTrigger) {
+:where(.MarkpromptFloatingTrigger) {
   display: flex;
   cursor: pointer;
   border-radius: 99999px;
@@ -71,8 +75,39 @@
   transition-duration: 200ms;
 }
 
-:where(.MarkpromptTrigger:hover) {
+:where(.MarkpromptFloatingTrigger:hover) {
   opacity: 0.8;
+}
+
+:where(.MarkpromptSearchBoxTrigger) {
+  display: flex;
+  cursor: pointer;
+  color: var(--markprompt-mutedForeground);
+  background-color: var(--markprompt-muted);
+  border: var(--markprompt-border);
+  border-radius: 0.25rem;
+  font-size: 0.8rem;
+  min-width: 10rem;
+}
+
+:where(.MarkpromptSearchBoxTriggerContent) {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  padding: 0.25rem 0.5rem;
+  width: 100%;
+}
+
+:where(.MarkPromptSearchBoxTriggerText) {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+:where(.MarkpromptSearchBoxTriggerContent kbd) {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
 }
 
 :where(.MarkpromptIcon) {

--- a/packages/docusaurus-theme-search/README.md
+++ b/packages/docusaurus-theme-search/README.md
@@ -14,15 +14,13 @@ A [Markprompt](https://markprompt.com) plugin for [Docusaurus](https://docusauru
 
 ## Table of Contents
 
-- [Markprompt Docusaurus plugin](#markprompt-docusaurus-plugin)
-  - [Table of Contents](#table-of-contents)
-  - [Installation](#installation)
-  - [Usage](#usage)
-    - [Basic Usage](#basic-usage)
-    - [Swizzling](#swizzling)
-  - [Example](#example)
-  - [Community](#community)
-  - [Authors](#authors)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Basic Usage](#basic-usage)
+  - [Swizzling](#swizzling)
+- [Example](#example)
+- [Community](#community)
+- [Authors](#authors)
 
 ## Installation
 

--- a/packages/docusaurus-theme-search/src/index.cts
+++ b/packages/docusaurus-theme-search/src/index.cts
@@ -7,7 +7,7 @@ declare namespace themeSearchMarkprompt {
   export type MarkpromptConfig = Omit<RootProps, 'children'>;
 
   export interface ThemeConfig {
-    markprompt?: MarkpromptConfig;
+    markprompt?: Omit<MarkpromptConfig, 'isSearchActive' | 'searchOptions'>;
   }
 }
 

--- a/packages/react/src/headless.tsx
+++ b/packages/react/src/headless.tsx
@@ -346,6 +346,7 @@ const Prompt = forwardRef<HTMLInputElement, PromptProps>(function Prompt(
           break;
         }
         case 'Enter': {
+          if (event.ctrlKey || event.metaKey) return;
           if (!activeSearchResult) return;
           event.preventDefault();
           // assumption here is that the search result will always contain an a element

--- a/packages/react/src/headless.tsx
+++ b/packages/react/src/headless.tsx
@@ -33,13 +33,7 @@ import type {
 import { useMarkprompt } from './useMarkprompt.js';
 import { type UseMarkpromptOptions } from './useMarkprompt.js';
 
-type RootProps = ComponentPropsWithoutRef<typeof Dialog.Root> &
-  UseMarkpromptOptions & {
-    children: ReactNode;
-    projectKey: string;
-    isSearchEnabled?: boolean;
-    isSearchActive?: boolean;
-  } & SubmitPromptOptions;
+type RootProps = Dialog.DialogProps & UseMarkpromptOptions;
 
 /**
  * The Markprompt context provider and dialog root.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -14,19 +14,17 @@ A prebuilt version of the Markprompt dialog, based on `@markprompt/react`, built
 
 ## Table of Contents
 
-- [`@markprompt/web`](#markpromptweb)
-  - [Table of Contents](#table-of-contents)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [Usage via `<script>` tag](#usage-via-script-tag)
-  - [API](#api)
-    - [`markprompt(projectKey, container, options?)`](#markpromptprojectkey-container-options)
-      - [Arguments](#arguments)
-      - [Options](#options)
-  - [Documentation](#documentation)
-  - [Community](#community)
-  - [Authors](#authors)
-  - [License](#license)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Usage via `<script>` tag](#usage-via-script-tag)
+- [API](#api)
+  - [`markprompt(projectKey, container, options?)`](#markpromptprojectkey-container-options)
+    - [Arguments](#arguments)
+    - [Options](#options)
+- [Documentation](#documentation)
+- [Community](#community)
+- [Authors](#authors)
+- [License](#license)
 
 ## Installation
 

--- a/packages/web/src/Markprompt.tsx
+++ b/packages/web/src/Markprompt.tsx
@@ -9,6 +9,8 @@ import React, {
   useState,
   type ReactElement,
   type ReactNode,
+  type Dispatch,
+  type SetStateAction,
 } from 'react';
 
 import { Answer } from './Answer.js';
@@ -25,9 +27,18 @@ import { References } from './References.js';
 import { SearchResult } from './SearchResult.js';
 import { type MarkpromptOptions } from './types.js';
 
-type MarkpromptProps = MarkpromptOptions & {
-  projectKey: string;
-};
+type MarkpromptProps = MarkpromptOptions &
+  Omit<
+    BaseMarkprompt.RootProps,
+    | 'children'
+    | 'isSearchActive'
+    | 'open'
+    | 'onOpenChange'
+    | 'promptOptions'
+    | 'searchOptions'
+  > & {
+    projectKey: string;
+  };
 
 function useToggle(initial: boolean): [on: boolean, toggle: () => void] {
   const [on, set] = useState(initial);
@@ -48,6 +59,8 @@ function Markprompt(props: MarkpromptProps): ReactElement {
     ...dialogProps
   } = props;
 
+  const [open, setOpen] = useState(false);
+
   const [showSearch, toggle] = useToggle(search?.enable ?? false);
 
   return (
@@ -56,13 +69,19 @@ function Markprompt(props: MarkpromptProps): ReactElement {
       isSearchActive={showSearch}
       promptOptions={prompt}
       searchOptions={search}
+      open={open}
+      onOpenChange={setOpen}
       {...dialogProps}
     >
-      <BaseMarkprompt.DialogTrigger className="MarkpromptTrigger">
-        <AccessibleIcon.Root label={trigger?.label ?? 'Open Markprompt'}>
-          <ChatIcon className="MarkpromptChatIcon" width="24" height="24" />
-        </AccessibleIcon.Root>
-      </BaseMarkprompt.DialogTrigger>
+      {trigger?.floating ? (
+        <BaseMarkprompt.DialogTrigger className="MarkpromptFloatingTrigger">
+          <AccessibleIcon.Root label={trigger?.label ?? 'Open Markprompt'}>
+            <ChatIcon className="MarkpromptChatIcon" width="24" height="24" />
+          </AccessibleIcon.Root>
+        </BaseMarkprompt.DialogTrigger>
+      ) : (
+        <SearchBoxTrigger trigger={trigger} setOpen={setOpen} open={open} />
+      )}
 
       <BaseMarkprompt.Portal>
         <BaseMarkprompt.Overlay className="MarkpromptOverlay" />
@@ -83,7 +102,12 @@ function Markprompt(props: MarkpromptProps): ReactElement {
           <BaseMarkprompt.Form className="MarkpromptForm">
             <BaseMarkprompt.Prompt
               className="MarkpromptPrompt"
-              placeholder={prompt?.placeholder ?? 'Search or ask a question…'}
+              placeholder={
+                prompt?.placeholder ??
+                (search?.enable
+                  ? 'Search or ask a question…'
+                  : 'Ask me anything…')
+              }
               labelClassName="MarkpromptPromptLabel"
               label={
                 <AccessibleIcon.Root
@@ -192,6 +216,56 @@ const Transition = (props: TransitionProps): ReactElement => {
     </animated.div>
   );
 };
+
+interface SearchBoxTriggerProps {
+  trigger: MarkpromptOptions['trigger'];
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+function SearchBoxTrigger(props: SearchBoxTriggerProps): ReactElement {
+  const { trigger, setOpen, open } = props;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (open) return;
+      if (
+        (event.key === 'Enter' && event.ctrlKey) ||
+        (event.key === 'Enter' && event.metaKey)
+      ) {
+        event.preventDefault();
+        setOpen(true);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, setOpen]);
+
+  return (
+    <BaseMarkprompt.DialogTrigger className="MarkpromptSearchBoxTrigger">
+      <AccessibleIcon.Root label={trigger?.label ?? 'Open Markprompt'}>
+        <span className="MarkpromptSearchBoxTriggerContent">
+          <span className="MarkPromptSearchBoxTriggerText">
+            <SearchIcon width={16} height={16} /> Search{' '}
+          </span>
+          <kbd>
+            {navigator.platform.indexOf('Mac') === 0 ||
+            navigator.platform === 'iPhone' ? (
+              <CommandIcon className="MarkpromptKeyboardKey" />
+            ) : (
+              <ChevronUpIcon className="MarkpromptKeyboardKey" />
+            )}
+            <CornerDownLeftIcon className="MarkpromptKeyboardKey" />
+          </kbd>
+        </span>
+      </AccessibleIcon.Root>
+    </BaseMarkprompt.DialogTrigger>
+  );
+}
 
 type SearchResultsContainerProps = {
   getResultHref?: (result: BaseMarkprompt.FlattenedSearchResult) => string;

--- a/packages/web/src/Markprompt.tsx
+++ b/packages/web/src/Markprompt.tsx
@@ -45,7 +45,7 @@ function Markprompt(props: MarkpromptProps): ReactElement {
     trigger,
     search,
     showBranding = true,
-    ...options
+    ...dialogProps
   } = props;
 
   const [showSearch, toggle] = useToggle(search?.enable ?? false);
@@ -53,9 +53,10 @@ function Markprompt(props: MarkpromptProps): ReactElement {
   return (
     <BaseMarkprompt.Root
       projectKey={projectKey}
-      isSearchEnabled={search?.enable}
       isSearchActive={showSearch}
-      {...options}
+      promptOptions={prompt}
+      searchOptions={search}
+      {...dialogProps}
     >
       <BaseMarkprompt.DialogTrigger className="MarkpromptTrigger">
         <AccessibleIcon.Root label={trigger?.label ?? 'Open Markprompt'}>

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 
 import { Markprompt } from './Markprompt.js';
 import { type MarkpromptOptions } from './types.js';
@@ -14,8 +14,10 @@ function getHTMLElement(
   return el;
 }
 
+let root: Root;
+
 /**
- * Render a markprompt dialog button.
+ * Render a markprompt dialog.
  *
  * @param projectKey Your Markprompt project key
  * @param container The element or selector to render Markprompt into
@@ -26,6 +28,6 @@ export function markprompt(
   container: HTMLElement | string,
   options?: MarkpromptOptions,
 ): void {
-  const { render } = createRoot(getHTMLElement(container));
-  render(<Markprompt projectKey={projectKey} {...options} />);
+  if (!root) root = createRoot(getHTMLElement(container));
+  root.render(<Markprompt projectKey={projectKey} {...options} />);
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,7 +1,10 @@
-import { type SubmitPromptOptions } from '@markprompt/core';
-import type { FlattenedSearchResult } from '@markprompt/react';
+import {
+  type SubmitPromptOptions,
+  type SubmitSearchQueryOptions,
+} from '@markprompt/core';
+import type { FlattenedSearchResult, RootProps } from '@markprompt/react';
 
-type MarkpromptOptions = SubmitPromptOptions & {
+type MarkpromptOptions = Omit<RootProps, 'children'> & {
   close?: {
     /**
      * `aria-label` for the close modal button
@@ -20,16 +23,7 @@ type MarkpromptOptions = SubmitPromptOptions & {
      **/
     text?: string;
   };
-  search?: {
-    /**
-     * Enable search
-     * @default false
-     **/
-    enable?: boolean;
-    /** Callback to transform a search result into an href */
-    getResultHref?: (result: FlattenedSearchResult) => string;
-  };
-  prompt?: {
+  prompt?: SubmitPromptOptions & {
     /**
      * Label for the prompt input
      * @default "Ask me anything…"
@@ -56,6 +50,18 @@ type MarkpromptOptions = SubmitPromptOptions & {
      * @default "Answer generated from the following sources:"
      **/
     referencesText?: string;
+  };
+  /**
+   * Enable and configure search functionality
+   */
+  search?: SubmitSearchQueryOptions & {
+    /**
+     * Enable search
+     * @default false
+     **/
+    enable?: boolean;
+    /** Callback to transform a search result into an href */
+    getResultHref?: (result: FlattenedSearchResult) => string;
   };
   trigger?: {
     /**

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -2,9 +2,9 @@ import {
   type SubmitPromptOptions,
   type SubmitSearchQueryOptions,
 } from '@markprompt/core';
-import type { FlattenedSearchResult, RootProps } from '@markprompt/react';
+import type { FlattenedSearchResult } from '@markprompt/react';
 
-type MarkpromptOptions = Omit<RootProps, 'children'> & {
+type MarkpromptOptions = {
   close?: {
     /**
      * `aria-label` for the close modal button
@@ -69,6 +69,12 @@ type MarkpromptOptions = Omit<RootProps, 'children'> & {
      * @default "Open Markprompt"
      **/
     label?: string;
+    /**
+     * Should the trigger button be displayed as a floating button at the bottom right of the page?
+     * Setting this to false will display a trigger button in the element passed
+     * to the `markprompt` function.
+     */
+    floating?: boolean;
   };
   title?: {
     /**


### PR DESCRIPTION
- Adds a new trigger button for the dialog with the appearance of a search input to `@markprompt/web`
- Clean up type definitions and the way that options are passed for `markprompt()`, `Markprompt` from `@markprompt/web` and `Markprompt.Root`