### PR TITLE
Content only

### DIFF
--- a/.changeset/ten-cars-boil.md
+++ b/.changeset/ten-cars-boil.md
@@ -1,0 +1,7 @@
+---
+'@markprompt/react': minor
+'@markprompt/css': minor
+'@markprompt/web': minor
+---
+
+Add plain display option

--- a/examples/with-css-modules/src/App.tsx
+++ b/examples/with-css-modules/src/App.tsx
@@ -37,7 +37,7 @@ function Component(): ReactElement {
       </Markprompt.DialogTrigger>
       <Markprompt.Portal>
         <Markprompt.Overlay className={styles.MarkpromptOverlay} />
-        <Markprompt.Content className={styles.MarkpromptContent}>
+        <Markprompt.Content className={styles.MarkpromptContentDialog}>
           <Markprompt.Close className={styles.MarkpromptClose}>
             <CloseIcon />
           </Markprompt.Close>

--- a/examples/with-css-modules/src/markprompt.module.css
+++ b/examples/with-css-modules/src/markprompt.module.css
@@ -74,7 +74,7 @@ button {
   background-color: var(--markprompt-overlay);
 }
 
-.MarkpromptContent {
+.MarkpromptContentDialog {
   background-color: var(--markprompt-background);
   border-radius: var(--markprompt-radius);
   border: 1px solid var(--markprompt-border);

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -47,7 +47,8 @@ The package adds styling using the following classes.
 - `MarkpromptAutoScroller`
 - `MarkpromptCaret`
 - `MarkpromptClose`
-- `MarkpromptContent`
+- `MarkpromptContentDialog`
+- `MarkpromptContentPlain`
 - `MarkpromptForm`
 - `MarkpromptIcon`
 - `MarkpromptOverlay`

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -142,7 +142,7 @@
   background-color: var(--markprompt-overlay);
 }
 
-:where(.MarkpromptContent) {
+:where(.MarkpromptContentDialog) {
   background-color: var(--markprompt-background);
   border-radius: var(--markprompt-radius);
   border: 1px solid var(--markprompt-border);
@@ -160,6 +160,18 @@
   animation-duration: 300ms;
   animation-fill-mode: both;
   transition-timing-function: cubic-bezier(0.25, 0.4, 0.55, 1.4);
+  color: var(--markprompt-foreground);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+:where(.MarkpromptContentPlain) {
+  background-color: var(--markprompt-background);
+  width: 100%;
+  height: 100%;
   color: var(--markprompt-foreground);
   overflow: hidden;
   display: grid;

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -55,6 +55,7 @@ replacing `YOUR-PROJECT-KEY` with the key associated to your project. It can be 
 The pre-built Markprompt component. It accepts the following props:
 
 - `projectKey` (`string`): The project key associated to your project. It can be obtained in the project settings on [Markprompt.com](https://markprompt.com/) under "Project key".
+- `display` (`plain | dialog`): The way to display the prompt (Default: `dialog`)
 - `close` (`object`): Options for the close modal button
 - `close.label` (`string`): `aria-label` for the close modal button (Default: `Close Markprompt`)
 - `description` (`object`): Options for the description

--- a/packages/react/src/constants.tsx
+++ b/packages/react/src/constants.tsx
@@ -57,6 +57,7 @@ const defaultGetResultHref = (
 };
 
 export const DEFAULT_MARKPROMPT_OPTIONS: MarkpromptOptions = {
+  display: 'dialog',
   close: {
     label: 'Close Markprompt',
   },

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -41,6 +41,7 @@ type RootProps = Dialog.DialogProps & UseMarkpromptOptions;
 function Root(props: RootProps): ReactElement {
   const {
     children,
+    display,
     defaultOpen,
     modal,
     onOpenChange,
@@ -58,14 +59,17 @@ function Root(props: RootProps): ReactElement {
 
   return (
     <MarkpromptContext.Provider value={contextValue}>
-      <DialogRootWithAbort
-        defaultOpen={defaultOpen}
-        modal={modal}
-        onOpenChange={onOpenChange}
-        open={open}
-      >
-        {children}
-      </DialogRootWithAbort>
+      {display === 'dialog' && (
+        <DialogRootWithAbort
+          defaultOpen={defaultOpen}
+          modal={modal}
+          onOpenChange={onOpenChange}
+          open={open}
+        >
+          {children}
+        </DialogRootWithAbort>
+      )}
+      {display === 'plain' && children}
     </MarkpromptContext.Provider>
   );
 }
@@ -144,6 +148,31 @@ const Content = forwardRef<HTMLDivElement, ContentProps>(function Content(
   );
 });
 Content.displayName = 'Markprompt.Content';
+
+type PlainContentProps = ComponentPropsWithRef<'div'> & {
+  /**
+   * Show the Markprompt footer.
+   */
+  showBranding?: boolean;
+};
+
+/**
+ * The Markprompt plain content.
+ */
+const PlainContent = forwardRef<HTMLDivElement, PlainContentProps>(
+  function PlainContent(props, ref) {
+    const { showBranding = true } = props;
+    const { state } = useMarkpromptContext();
+
+    return (
+      <div {...props} ref={ref} data-loading-state={state}>
+        {props.children}
+        {showBranding && <Footer />}
+      </div>
+    );
+  },
+);
+PlainContent.displayName = 'Markprompt.PlainContent';
 
 type CloseProps = ComponentPropsWithRef<typeof Dialog.Close>;
 /**
@@ -617,6 +646,7 @@ export {
   AutoScroller,
   Close,
   Content,
+  PlainContent,
   Description,
   DialogTrigger,
   Form,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -52,6 +52,11 @@ export type SearchResultWithMetadata = {
 };
 
 type MarkpromptOptions = {
+  /**
+   * Display format.
+   * @default "dialog"
+   **/
+  display?: 'plain' | 'dialog';
   close?: {
     /**
      * `aria-label` for the close modal button

--- a/packages/react/src/useMarkprompt.tsx
+++ b/packages/react/src/useMarkprompt.tsx
@@ -15,7 +15,7 @@ import {
   type SetStateAction,
 } from 'react';
 
-import type { SearchResultWithMetadata } from './types.js';
+import type { MarkpromptOptions, SearchResultWithMetadata } from './types.js';
 
 export type LoadingState =
   | 'indeterminate'
@@ -26,6 +26,8 @@ export type LoadingState =
 export interface UseMarkpromptOptions {
   /** Project key, required */
   projectKey: string;
+  /** Project key, required */
+  display?: MarkpromptOptions['display'];
   /** Is search currently active */
   isSearchActive?: boolean;
   /** Enable and configure prompt functionality */

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -62,6 +62,11 @@ import {
 import type { SearchResultWithMetadata } from '@markprompt/react';
 
 type MarkpromptOptions = {
+  /**
+   * Display format.
+   * @default "dialog"
+   **/
+  display?: 'plain' | 'dialog';
   close?: {
     /**
      * `aria-label` for the close modal button


### PR DESCRIPTION
Add a `display` parameter to `MarkpromptOptions`, allowing to show the prompt without a dialog/trigger. This is necessary e.g. for iframe embeds. Supported values are `dialog` (default) and `plain`.