### PR TITLE
Add a feedback component to the prompt view

### DIFF
--- a/.changeset/twenty-icons-judge.md
+++ b/.changeset/twenty-icons-judge.md
@@ -1,0 +1,9 @@
+---
+'@markprompt/react': minor
+'@markprompt/core': minor
+'@markprompt/css': minor
+'@markprompt/docusaurus-theme-search': minor
+'@markprompt/web': minor
+---
+
+Add feedback functionality to the prompt, allowing users to give feedback on the usefulness of prompt answers

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -7,7 +7,8 @@ const el = document.querySelector('#markprompt');
 
 if (el && el instanceof HTMLElement) {
   markprompt(import.meta.env.VITE_PROJECT_API_KEY, el, {
-    trigger: { floating: true },
+    feedback: { enabled: true },
     search: { enabled: false },
+    trigger: { floating: true },
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5868,6 +5868,19 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "devOptional": true,
@@ -22749,6 +22762,7 @@
         "@testing-library/jest-dom": "^5.0.0",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^8.0.0",
+        "@testing-library/user-event": "^14.4.3",
         "jsdom": "^22.0.0"
       },
       "peerDependencies": {

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -1,10 +1,18 @@
-interface SubmitFeedbackBody {
+export interface SubmitFeedbackBody {
+  /**
+   * Whether the prompt was helpful or not.
+   */
   helpful: boolean;
+  /** ID of the prompt for which feedback is being submitted. */
   promptId: string;
 }
 
-interface SubmitFeedbackOptions {
-  feedbackUrl: 'https://api.markprompt.com/v1/feedback';
+export interface SubmitFeedbackOptions {
+  /**
+   * URL to submit feedback to.
+   * @default 'https://api.markprompt.com/v1/feedback'
+   */
+  feedbackUrl?: string;
   signal?: AbortSignal;
 }
 

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -1,0 +1,51 @@
+interface SubmitFeedbackBody {
+  helpful: boolean;
+  promptId: string;
+}
+
+interface SubmitFeedbackOptions {
+  feedbackUrl: 'https://api.markprompt.com/v1/feedback';
+  signal?: AbortSignal;
+}
+
+export const DEFAULT_SUBMIT_FEEDBACK_OPTIONS = {
+  feedbackUrl: 'https://api.markprompt.com/v1/feedback',
+} satisfies SubmitFeedbackOptions;
+
+export async function submitFeedback(
+  projectKey: string,
+  body: SubmitFeedbackBody,
+  options?: SubmitFeedbackOptions,
+): Promise<void> {
+  const { feedbackUrl = DEFAULT_SUBMIT_FEEDBACK_OPTIONS.feedbackUrl, signal } =
+    options ?? {};
+
+  const params = new URLSearchParams({
+    projectKey,
+  });
+
+  try {
+    const response = await fetch(feedbackUrl + `?${params}`, {
+      method: 'POST',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(body),
+      signal,
+    });
+
+    if (!response.ok) {
+      const error = (await response.json())?.error;
+      throw new Error(`Failed to submit feedback: ${error || 'Unknown error'}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      // do nothing on AbortError's, this is expected
+      return undefined;
+    } else {
+      throw error;
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  submitFeedback,
+  type SubmitFeedbackOptions,
+  type SubmitFeedbackBody,
+  DEFAULT_SUBMIT_FEEDBACK_OPTIONS,
+} from './feedback.js';
+
+export {
   submitPrompt,
   type SubmitPromptOptions,
   DEFAULT_SUBMIT_PROMPT_OPTIONS,

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -111,9 +111,9 @@ export async function submitPrompt(
       options.completionsUrl ?? DEFAULT_SUBMIT_PROMPT_OPTIONS.completionsUrl!,
       {
         method: 'POST',
-        headers: {
+        headers: new Headers({
           'Content-Type': 'application/json',
-        },
+        }),
         body: JSON.stringify({
           prompt: prompt,
           projectKey: projectKey,

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -758,7 +758,6 @@
 }
 
 :where(.MarkpromptPromptFeedback p) {
-  background-color: var(--markprompt-muted);
   font-size: var(--markprompt-text-size);
   margin-top: 0;
   margin-bottom: 0.5rem;

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -742,6 +742,53 @@
   display: inline-block;
 }
 
+:where(.MarkpromptPromptFeedback) {
+  /* background-color: var(--markprompt-muted); */
+  margin: 0 2rem 1.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--markprompt-border);
+  border-radius: 0.25rem;
+}
+
+:where(.MarkpromptPromptFeedback h3) {
+  font-size: var(--markprompt-text-size);
+  font-weight: 600;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+:where(.MarkpromptPromptFeedback p) {
+  background-color: var(--markprompt-muted);
+  font-size: var(--markprompt-text-size);
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+:where(.MarkpromptPromptFeedback div) {
+  display: flex;
+  gap: 0.25rem;
+}
+
+:where(.MarkpromptPromptFeedback button) {
+  cursor: pointer;
+  color: var(--markprompt-mutedForeground);
+  border: 1px solid var(--markprompt-border);
+  background-color: var(--markprompt-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+}
+
+:where(.MarkpromptPromptFeedback button svg) {
+  display: block;
+}
+
+:where(.MarkpromptPromptFeedback button:hover) {
+  opacity: 0.8;
+}
+
 :where([data-loading-state='preload'] .MarkpromptProgress) {
   position: absolute;
   top: -1px;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,6 +38,7 @@
     "@testing-library/jest-dom": "^5.0.0",
     "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^8.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "jsdom": "^22.0.0"
   },
   "peerDependencies": {

--- a/packages/react/src/Feedback.test.tsx
+++ b/packages/react/src/Feedback.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React, { createContext } from 'react';
+import React from 'react';
 import { describe, expect, test, vitest } from 'vitest';
 
 import { MarkpromptContext } from './context';

--- a/packages/react/src/Feedback.test.tsx
+++ b/packages/react/src/Feedback.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React, { createContext } from 'react';
 import { describe, expect, test, vitest } from 'vitest';
 
-import { MarkpromptContext } from './context.js';
-import { Feedback } from './feedback.js';
+import { MarkpromptContext } from './context';
+import { Feedback } from './Feedback';
 
 const submitFeedback = vitest.fn((helpful: boolean) => Promise.resolve());
 

--- a/packages/react/src/Feedback.test.tsx
+++ b/packages/react/src/Feedback.test.tsx
@@ -1,0 +1,63 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { createContext } from 'react';
+import { describe, expect, test, vitest } from 'vitest';
+
+import { MarkpromptContext } from './context.js';
+import { Feedback } from './feedback.js';
+
+const submitFeedback = vitest.fn((helpful: boolean) => Promise.resolve());
+
+const mockContextValue = {
+  activeSearchResult: undefined,
+  answer: undefined,
+  isSearchEnabled: false,
+  isSearchActive: false,
+  prompt: '',
+  references: [],
+  searchResults: [],
+  state: 'indeterminate' as const,
+  abort: vitest.fn(),
+  submitFeedback: submitFeedback,
+  submitPrompt: vitest.fn(),
+  submitSearchQuery: vitest.fn(),
+  updateActiveSearchResult: vitest.fn(),
+  updatePrompt: vitest.fn(),
+};
+
+describe('Feedback', () => {
+  test('render the Feedback component', () => {
+    render(<Feedback />);
+
+    const element = screen.getByText(
+      /Was this response helpful?/,
+    ).parentElement;
+
+    expect(element).toBeInTheDocument();
+  });
+
+  test('thank the user when feedback was provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MarkpromptContext.Provider value={mockContextValue}>
+        <Feedback />
+      </MarkpromptContext.Provider>,
+    );
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+
+    const yesButton = screen.getByLabelText('Yes');
+
+    await act(async () => {
+      await user.click(yesButton);
+    });
+
+    await waitFor(() => expect(submitFeedback).toHaveBeenCalledWith(true));
+
+    expect(
+      screen.getByText(/Thanks for helping us improve our responses./),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/Feedback.tsx
+++ b/packages/react/src/Feedback.tsx
@@ -4,16 +4,18 @@ import React, {
   type ComponentPropsWithoutRef,
 } from 'react';
 
+import { useMarkpromptContext } from './context.js';
 import { ThumbsDownIcon, ThumbsUpIcon } from './icons.js';
 
 export function Feedback(
   props: ComponentPropsWithoutRef<'aside'>,
 ): ReactElement {
+  const { submitFeedback } = useMarkpromptContext();
   const [feedback, setFeedback] = useState<boolean>();
 
   async function handleFeedback(helpful: boolean): Promise<void> {
-    // TODO: Send feedback to server
     setFeedback(helpful);
+    await submitFeedback(helpful);
   }
 
   return (

--- a/packages/react/src/Feedback.tsx
+++ b/packages/react/src/Feedback.tsx
@@ -24,10 +24,10 @@ export function Feedback(
 
       {typeof feedback !== 'boolean' && (
         <div>
-          <button onClick={() => handleFeedback(true)}>
+          <button aria-label="Yes" onClick={() => handleFeedback(true)}>
             <ThumbsUpIcon width={16} height={16} />
           </button>
-          <button onClick={() => handleFeedback(false)}>
+          <button aria-label="No" onClick={() => handleFeedback(false)}>
             <ThumbsDownIcon width={16} height={16} />
           </button>
         </div>

--- a/packages/react/src/Feedback.tsx
+++ b/packages/react/src/Feedback.tsx
@@ -14,8 +14,8 @@ export function Feedback(
   const [feedback, setFeedback] = useState<boolean>();
 
   async function handleFeedback(helpful: boolean): Promise<void> {
-    setFeedback(helpful);
     await submitFeedback(helpful);
+    setFeedback(helpful);
   }
 
   return (

--- a/packages/react/src/Feedback.tsx
+++ b/packages/react/src/Feedback.tsx
@@ -1,0 +1,39 @@
+import React, {
+  useState,
+  type ReactElement,
+  type ComponentPropsWithoutRef,
+} from 'react';
+
+import { ThumbsDownIcon, ThumbsUpIcon } from './icons.js';
+
+export function Feedback(
+  props: ComponentPropsWithoutRef<'aside'>,
+): ReactElement {
+  const [feedback, setFeedback] = useState<boolean>();
+
+  async function handleFeedback(helpful: boolean): Promise<void> {
+    // TODO: Send feedback to server
+    setFeedback(helpful);
+  }
+
+  return (
+    <aside {...props}>
+      <h3>Was this response helpful?</h3>
+
+      {typeof feedback !== 'boolean' && (
+        <div>
+          <button onClick={() => handleFeedback(true)}>
+            <ThumbsUpIcon width={16} height={16} />
+          </button>
+          <button onClick={() => handleFeedback(false)}>
+            <ThumbsDownIcon width={16} height={16} />
+          </button>
+        </div>
+      )}
+
+      {typeof feedback === 'boolean' && (
+        <p>Thanks for helping us improve our responses.</p>
+      )}
+    </aside>
+  );
+}

--- a/packages/react/src/Markprompt.tsx
+++ b/packages/react/src/Markprompt.tsx
@@ -536,7 +536,6 @@ function AnswerContainer({
 
       <BaseMarkprompt.AutoScroller className="MarkpromptAutoScroller">
         <Answer />
-        <Feedback className="MarkpromptPromptFeedback" />
         {feedback?.enabled && state === 'done' && (
           <Feedback className="MarkpromptPromptFeedback" />
         )}

--- a/packages/react/src/Markprompt.tsx
+++ b/packages/react/src/Markprompt.tsx
@@ -15,6 +15,7 @@ import React, {
 import { Answer } from './Answer.js';
 import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
 import { useMarkpromptContext } from './context.js';
+import { Feedback } from './Feedback.js';
 import {
   ChatIcon,
   ChevronLeftIcon,
@@ -160,7 +161,7 @@ function Markprompt(props: MarkpromptProps): ReactElement {
 
 type MarkpromptContentProps = Pick<
   MarkpromptProps,
-  'close' | 'prompt' | 'references' | 'search'
+  'close' | 'feedback' | 'prompt' | 'references' | 'search'
 > & {
   showSearch?: boolean;
   toggleSearch?: () => void;
@@ -173,12 +174,13 @@ export const noop = (): void => {};
 function MarkpromptContent(props: MarkpromptContentProps): ReactElement {
   const {
     close,
+    feedback,
+    includeClose = true,
     prompt,
     references,
     search,
     showSearch = false,
     toggleSearch = noop,
-    includeClose = true,
   } = props;
 
   return (
@@ -214,6 +216,7 @@ function MarkpromptContent(props: MarkpromptContentProps): ReactElement {
       </BaseMarkprompt.Form>
 
       <AnswerOrSearchResults
+        feedback={feedback}
         search={search}
         references={references}
         showSearch={showSearch}
@@ -225,22 +228,30 @@ function MarkpromptContent(props: MarkpromptContentProps): ReactElement {
 }
 
 type AnswerOrSearchResultsProps = {
+  feedback?: MarkpromptOptions['feedback'];
+  promptCTA?: string;
   references: MarkpromptOptions['references'];
   search?: MarkpromptOptions['search'];
   showSearch: boolean;
-  promptCTA?: string;
   toggleSearchAnswer: () => void;
 };
 
 function AnswerOrSearchResults(
   props: AnswerOrSearchResultsProps,
 ): ReactElement {
-  const { search, showSearch, promptCTA, toggleSearchAnswer, references } =
-    props;
+  const {
+    feedback,
+    promptCTA,
+    references,
+    search,
+    showSearch,
+    toggleSearchAnswer,
+  } = props;
 
   if (!search?.enabled) {
     return (
       <AnswerContainer
+        feedback={feedback}
         isSearchEnabled={search?.enabled}
         references={references}
         toggleSearchAnswer={toggleSearchAnswer}
@@ -260,6 +271,7 @@ function AnswerOrSearchResults(
       </Transition>
       <Transition isVisible={!showSearch} isFlipped>
         <AnswerContainer
+          feedback={feedback}
           isSearchEnabled={search?.enabled}
           references={references}
           toggleSearchAnswer={toggleSearchAnswer}
@@ -491,6 +503,7 @@ function SearchResultsContainer(
 }
 
 type AnswerContainerProps = {
+  feedback?: MarkpromptOptions['feedback'];
   isSearchEnabled?: boolean;
   references: MarkpromptOptions['references'];
   toggleSearchAnswer: () => void;
@@ -499,9 +512,10 @@ type AnswerContainerProps = {
 function AnswerContainer({
   isSearchEnabled,
   references,
+  feedback,
   toggleSearchAnswer,
 }: AnswerContainerProps): ReactElement {
-  const { abort } = useMarkpromptContext();
+  const { abort, state } = useMarkpromptContext();
 
   return (
     <div className="MarkpromptPromptContainer">
@@ -522,6 +536,10 @@ function AnswerContainer({
 
       <BaseMarkprompt.AutoScroller className="MarkpromptAutoScroller">
         <Answer />
+        <Feedback className="MarkpromptPromptFeedback" />
+        {feedback?.enabled && state === 'done' && (
+          <Feedback className="MarkpromptPromptFeedback" />
+        )}
       </BaseMarkprompt.AutoScroller>
 
       <References

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -21,6 +21,7 @@ type State = {
 
 type Actions = {
   abort: () => void;
+  submitFeedback: (helpful: boolean) => void;
   submitPrompt: () => void;
   submitSearchQuery: (searchQuery: string) => void;
   updateActiveSearchResult: Dispatch<SetStateAction<string | undefined>>;
@@ -40,6 +41,7 @@ const MarkpromptContext = createContext<State & Actions>({
   searchResults: [],
   state: 'indeterminate',
   abort: noop,
+  submitFeedback: noop,
   submitPrompt: noop,
   submitSearchQuery: noop,
   updateActiveSearchResult: noop,

--- a/packages/react/src/icons.tsx
+++ b/packages/react/src/icons.tsx
@@ -153,6 +153,32 @@ const HashIcon = (props: ComponentPropsWithoutRef<'svg'>): ReactElement => (
   </svg>
 );
 
+export const ThumbsUpIcon = (
+  props: ComponentPropsWithoutRef<'svg'>,
+): ReactElement => (
+  <svg
+    fill="currentColor"
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 256 256"
+  >
+    <path d="M234,80.12A24,24,0,0,0,216,72H160V56a40,40,0,0,0-40-40,8,8,0,0,0-7.16,4.42L75.06,96H32a16,16,0,0,0-16,16v88a16,16,0,0,0,16,16H204a24,24,0,0,0,23.82-21l12-96A24,24,0,0,0,234,80.12ZM32,112H72v88H32ZM223.94,97l-12,96a8,8,0,0,1-7.94,7H88V105.89l36.71-73.43A24,24,0,0,1,144,56V80a8,8,0,0,0,8,8h64a8,8,0,0,1,7.94,9Z"></path>
+  </svg>
+);
+
+export const ThumbsDownIcon = (
+  props: ComponentPropsWithoutRef<'svg'>,
+): ReactElement => (
+  <svg
+    fill="currentColor"
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 256 256"
+  >
+    <path d="M239.82,157l-12-96A24,24,0,0,0,204,40H32A16,16,0,0,0,16,56v88a16,16,0,0,0,16,16H75.06l37.78,75.58A8,8,0,0,0,120,240a40,40,0,0,0,40-40V184h56a24,24,0,0,0,23.82-27ZM72,144H32V56H72Zm150,21.29a7.88,7.88,0,0,1-6,2.71H152a8,8,0,0,0-8,8v24a24,24,0,0,1-19.29,23.54L88,150.11V56H204a8,8,0,0,1,7.94,7l12,96A7.87,7.87,0,0,1,222,165.29Z"></path>
+  </svg>
+);
+
 export {
   ChatIcon,
   ChevronLeftIcon,

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -462,7 +462,7 @@ const AutoScroller = forwardRef<HTMLDivElement, AutoScrollerProps>(
   (props, ref) => {
     const { autoScroll = true, scrollBehavior = 'smooth' } = props;
     const localRef = useRef<HTMLDivElement>(null);
-    const { answer } = useMarkpromptContext();
+    const { answer, state } = useMarkpromptContext();
 
     useEffect(() => {
       if (!localRef.current) return;
@@ -471,7 +471,7 @@ const AutoScroller = forwardRef<HTMLDivElement, AutoScrollerProps>(
         top: localRef.current.scrollHeight,
         behavior: scrollBehavior,
       });
-    }, [answer, autoScroll, scrollBehavior]);
+    }, [answer, state, autoScroll, scrollBehavior]);
 
     return <div ref={mergeRefs([ref, localRef])} {...props} />;
   },

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -78,6 +78,14 @@ type MarkpromptOptions = {
      **/
     text?: string;
   };
+  feedback?: {
+    /**
+     * Enable feedback functionality, shows a thumbs up/down button after a
+     * prompt was submitted.
+     * @default false
+     * */
+    enabled?: boolean;
+  };
   prompt?: SubmitPromptOptions & {
     /**
      * Label for the prompt input

--- a/packages/react/src/useMarkprompt.test.ts
+++ b/packages/react/src/useMarkprompt.test.ts
@@ -61,6 +61,7 @@ describe('useMarkprompt', () => {
       references: [],
       searchResults: [],
       state: 'indeterminate',
+      submitFeedback: expect.any(Function),
       submitPrompt: expect.any(Function),
       submitSearchQuery: expect.any(Function),
       updateActiveSearchResult: expect.any(Function),


### PR DESCRIPTION
This PR adds an often requested feedback component, allowing users to provide feedback about the usefulness of the prompt answers through a simple yes/no question.

Backend for this change is not implemented yet, should hold off on merging until we do so.