### PR TITLE
Split search and prompt functionality

### DIFF
--- a/.changeset/dirty-cherries-explode.md
+++ b/.changeset/dirty-cherries-explode.md
@@ -1,0 +1,6 @@
+---
+'@markprompt/react': minor
+'@markprompt/css': minor
+---
+
+Split search and prompt functionality

--- a/.changeset/wet-masks-raise.md
+++ b/.changeset/wet-masks-raise.md
@@ -1,0 +1,8 @@
+---
+'@markprompt/react': minor
+'@markprompt/css': minor
+'@markprompt/docusaurus-theme-search': minor
+'@markprompt/web': minor
+---
+
+Split up search and prompt inputs to use different states

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -8,7 +8,7 @@ const el = document.querySelector('#markprompt');
 if (el && el instanceof HTMLElement) {
   markprompt(import.meta.env.VITE_PROJECT_API_KEY, el, {
     feedback: { enabled: false },
-    search: { enabled: false },
+    search: { enabled: true },
     trigger: { floating: true },
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,9 +89,8 @@
     },
     "examples/with-custom-trigger/node_modules/typescript": {
       "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2105,8 +2104,7 @@
     },
     "node_modules/@changesets/apply-release-plan": {
       "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
-      "integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/config": "^2.3.1",
@@ -2125,16 +2123,14 @@
     },
     "node_modules/@changesets/apply-release-plan/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
       "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
-      "integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
@@ -2162,8 +2158,7 @@
     },
     "node_modules/@changesets/cli": {
       "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
-      "integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/apply-release-plan": "^6.1.4",
@@ -2269,8 +2264,7 @@
     },
     "node_modules/@changesets/config": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
-      "integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
+      "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.1.4",
         "@changesets/get-dependents-graph": "^1.3.6",
@@ -2283,16 +2277,14 @@
     },
     "node_modules/@changesets/errors": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.1.4.tgz",
-      "integrity": "sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==",
+      "license": "MIT",
       "dependencies": {
         "extendable-error": "^0.1.5"
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
-      "integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
+      "license": "MIT",
       "dependencies": {
         "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
@@ -2303,8 +2295,7 @@
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2314,8 +2305,7 @@
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2327,37 +2317,32 @@
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "license": "MIT"
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -2375,8 +2360,7 @@
     },
     "node_modules/@changesets/get-release-plan": {
       "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
-      "integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/assemble-release-plan": "^5.2.4",
@@ -2389,13 +2373,11 @@
     },
     "node_modules/@changesets/get-version-range-type": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz",
-      "integrity": "sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg=="
+      "license": "MIT"
     },
     "node_modules/@changesets/git": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
-      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
@@ -2408,16 +2390,14 @@
     },
     "node_modules/@changesets/logger": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.0.5.tgz",
-      "integrity": "sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^2.1.0"
       }
     },
     "node_modules/@changesets/logger/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2427,8 +2407,7 @@
     },
     "node_modules/@changesets/logger/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2440,37 +2419,32 @@
     },
     "node_modules/@changesets/logger/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@changesets/logger/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "license": "MIT"
     },
     "node_modules/@changesets/logger/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@changesets/logger/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@changesets/logger/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -2480,8 +2454,7 @@
     },
     "node_modules/@changesets/parse": {
       "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
-      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
+      "license": "MIT",
       "dependencies": {
         "@changesets/types": "^5.2.1",
         "js-yaml": "^3.13.1"
@@ -2489,16 +2462,14 @@
     },
     "node_modules/@changesets/parse/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@changesets/parse/node_modules/js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2509,8 +2480,7 @@
     },
     "node_modules/@changesets/pre": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
-      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
@@ -2521,8 +2491,7 @@
     },
     "node_modules/@changesets/read": {
       "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
-      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/git": "^2.0.0",
@@ -2536,8 +2505,7 @@
     },
     "node_modules/@changesets/read/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2547,8 +2515,7 @@
     },
     "node_modules/@changesets/read/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2560,37 +2527,32 @@
     },
     "node_modules/@changesets/read/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@changesets/read/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "license": "MIT"
     },
     "node_modules/@changesets/read/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@changesets/read/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@changesets/read/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -2623,8 +2585,6 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
-      "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
       "dev": true,
       "funding": [
         {
@@ -2636,6 +2596,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2645,9 +2606,8 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz",
-      "integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2658,8 +2618,6 @@
     },
     "node_modules/@csstools/media-query-list-parser": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.0.tgz",
-      "integrity": "sha512-MXkR+TeaS2q9IkpyO6jVCdtA/bfpABJxIrfkLswThFN8EZZgI2RfAHhm6sDNDuYV25d5+b8Lj1fpTccIcSLPsQ==",
       "dev": true,
       "funding": [
         {
@@ -2671,6 +2629,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2681,9 +2640,8 @@
     },
     "node_modules/@csstools/selector-specificity": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "dev": true,
+      "license": "CC0-1.0",
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -3755,8 +3713,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -3776,8 +3733,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3798,8 +3754,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -3817,8 +3772,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -3841,8 +3795,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4021,8 +3974,7 @@
     },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "@types/node": "^12.7.1",
@@ -4032,13 +3984,11 @@
     },
     "node_modules/@manypkg/find-root/node_modules/@types/node": {
       "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+      "license": "MIT"
     },
     "node_modules/@manypkg/find-root/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -4049,8 +3999,7 @@
     },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -4062,8 +4011,7 @@
     },
     "node_modules/@manypkg/find-root/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -4073,8 +4021,7 @@
     },
     "node_modules/@manypkg/find-root/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -4084,8 +4031,7 @@
     },
     "node_modules/@manypkg/get-packages": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
-      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "@changesets/types": "^4.0.1",
@@ -4097,13 +4043,11 @@
     },
     "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="
+      "license": "MIT"
     },
     "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -4478,36 +4422,6 @@
       "version": "12.3.4",
       "license": "MIT"
     },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
-      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
-      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "12.3.4",
       "cpu": [
@@ -4517,156 +4431,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz",
-      "integrity": "sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
-      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
-      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz",
-      "integrity": "sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz",
-      "integrity": "sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz",
-      "integrity": "sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz",
-      "integrity": "sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz",
-      "integrity": "sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz",
-      "integrity": "sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
-      "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -4810,10 +4574,8 @@
     },
     "node_modules/@octokit/app": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-4.3.0.tgz",
-      "integrity": "sha512-TAi6Ju1u1rf7+V1vd2pg70SFwmHmwt5WAaAJ8BPaIHALxKbLpyyKUaVP1DBBmNmgF+fw0dwBR/edrClDMpdDfQ==",
-      "deprecated": "'@octokit/app' will be repurposed in future. Use '@octokit/auth-app' instead",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^5.0.0",
         "jsonwebtoken": "^8.3.0",
@@ -4822,18 +4584,16 @@
     },
     "node_modules/@octokit/auth-token": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3"
       }
     },
     "node_modules/@octokit/core": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -4846,9 +4606,8 @@
     },
     "node_modules/@octokit/endpoint": {
       "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
@@ -4857,18 +4616,16 @@
     },
     "node_modules/@octokit/endpoint/node_modules/is-plain-object": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@octokit/graphql": {
       "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
@@ -4877,15 +4634,13 @@
     },
     "node_modules/@octokit/openapi-types": {
       "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.40.0"
       },
@@ -4895,18 +4650,16 @@
     },
     "node_modules/@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.39.0",
         "deprecation": "^2.3.1"
@@ -4917,9 +4670,8 @@
     },
     "node_modules/@octokit/request": {
       "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
@@ -4931,9 +4683,8 @@
     },
     "node_modules/@octokit/request-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -4942,18 +4693,16 @@
     },
     "node_modules/@octokit/request/node_modules/is-plain-object": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@octokit/rest": {
       "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/core": "^3.5.1",
         "@octokit/plugin-paginate-rest": "^2.16.8",
@@ -4963,9 +4712,8 @@
     },
     "node_modules/@octokit/types": {
       "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
       }
@@ -5010,8 +4758,7 @@
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
-      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
@@ -5056,8 +4803,7 @@
     },
     "node_modules/@radix-ui/react-context": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
-      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -5073,8 +4819,7 @@
     },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
-      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -5097,8 +4842,7 @@
     },
     "node_modules/@radix-ui/react-id": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
-      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.1"
@@ -5154,8 +4898,7 @@
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
-      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -5171,8 +4914,7 @@
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
-      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.1"
@@ -5189,8 +4931,7 @@
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
-      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.1"
@@ -5207,8 +4948,7 @@
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
-      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -5597,159 +5337,14 @@
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.66.tgz",
-      "integrity": "sha512-UijJsvuLy73vxeVYEy7urIHksXS+3BdvJ9s9AY+bRMSQW483NO7RLp8g4FdTyJbRaN0BH15SQnY0dcjQBkVuHw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.66.tgz",
-      "integrity": "sha512-xGsHKvViQnwTNLF30Y/5OqWdnN6RsiyUI8awZXfz1sHcXCEaLe+v+WLQ+/E8sgw0YUkYVHzzfV/sAN2CezJK5Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.66.tgz",
-      "integrity": "sha512-gNbLcSIV2pq90BkMSpzvK4xPXOl8GEF3YR4NaqF0CYSzQsVXXTTqMuX/r26xNYudBKzH0345S1MpoRk2qricnA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.66.tgz",
-      "integrity": "sha512-cJSQ0oplyWbJqy4rzVcnBYLAi6z1QT3QCcR7iAey0aAmCvfRBZJfXlyjggMjn4iosuadkauwCZR1xYNhBDRn7w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.66.tgz",
-      "integrity": "sha512-GDQZpcB9aGxG9PTA2shdIkoMZlGK5omJ8NR49uoBTtLBVYiGeXAwV0U1Uaw8kXEZj9i7wZDkvjzjSaNH3evRsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.66.tgz",
-      "integrity": "sha512-lg8E4O/Pd9KfK0lajdinVMuGME8dSv7V9arhEpmlfGE2eXSDCWqDn5Htk5QVBstt9lt1lsRhWHJ/YYc2eQY30Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.66.tgz",
-      "integrity": "sha512-lo8ZcAO/zL2pZWH+LZIyge8u2MklaeuT6+FpVVpBFktMVdYXbaVtzpvWbgRFBZHvL3SRDF+u8jxjtkXhvGUpTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.66.tgz",
-      "integrity": "sha512-cQoVwBuJY5WkHbfpCOlndNwYr1ZThatRjQQvKy540NUIeAEk9Fa6ozlDBtU75UdaWKtUG6YQ/bWz+KTemheVxw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.66.tgz",
-      "integrity": "sha512-y/FrAIINK4UBeUQQknGlWXEyjo+MBvjF7WkUf2KP7sNr9EHHy8+dXohAGd5Anz0eJrqOM1ZXR/GEjxRp7bGQ1Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.66.tgz",
-      "integrity": "sha512-yI64ACzS14qFLrfyO12qW+f/UROTotzDeEbuyJAaPD2IZexoT1cICznI3sBmIfrSt33mVuW8eF5m3AG/NUImzw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -5871,9 +5466,8 @@
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.4.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
-      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -6217,8 +5811,7 @@
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -6302,8 +5895,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.1.tgz",
-      "integrity": "sha512-KSWsVvsJsLJv3c4e73y/Bzt7OpqMCADUO846bHcuWYSYM19bldbAeDv7dYyV0jwkbMfJ2XdlzwjhXtuD7OY6bw==",
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.60.1",
@@ -6335,8 +5927,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.1.tgz",
-      "integrity": "sha512-pHWlc3alg2oSMGwsU/Is8hbm3XFbcrb6P5wIxcQW9NsYBfnrubl/GhVVD/Jm/t8HXhA2WncoIRfBtnCgRGV96Q==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.60.1",
         "@typescript-eslint/types": "5.60.1",
@@ -6361,8 +5952,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.1.tgz",
-      "integrity": "sha512-Dn/LnN7fEoRD+KspEOV0xDMynEmR3iSHdgNsarlXNLGGtcUok8L4N71dxUgt3YvlO8si7E+BJ5Fe3wb5yUw7DQ==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.60.1",
         "@typescript-eslint/visitor-keys": "5.60.1"
@@ -6377,8 +5967,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.1.tgz",
-      "integrity": "sha512-vN6UztYqIu05nu7JqwQGzQKUJctzs3/Hg7E2Yx8rz9J+4LgtIDFWjjl1gm3pycH0P3mHAcEUBd23LVgfrsTR8A==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.60.1",
         "@typescript-eslint/utils": "5.60.1",
@@ -6403,8 +5992,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.1.tgz",
-      "integrity": "sha512-zDcDx5fccU8BA0IDZc71bAtYIcG9PowaOwaD8rjYbqwK7dpe/UMQl3inJ4UtUK42nOCT41jTSCwg76E62JpMcg==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6415,8 +6003,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.1.tgz",
-      "integrity": "sha512-hkX70J9+2M2ZT6fhti5Q2FoU9zb+GeZK2SLP1WZlvUDqdMbEKhexZODD1WodNRyO8eS+4nScvT0dts8IdaBzfw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.60.1",
         "@typescript-eslint/visitor-keys": "5.60.1",
@@ -6441,8 +6028,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.1.tgz",
-      "integrity": "sha512-tiJ7FFdFQOWssFa3gqb94Ilexyw0JVxj6vBzaSpfN/8IhoKkDuSAenUKvsSHw2A/TMpJb26izIszTXaqygkvpQ==",
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -6466,8 +6052,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.1.tgz",
-      "integrity": "sha512-xEYIxKcultP6E/RMKqube11pGjXH1DCo60mQoWhVYyKfLkwbIVVjYxmOenNMxILx0TjCujPTjjnTIVzm09TXIw==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.60.1",
         "eslint-visitor-keys": "^3.3.0"
@@ -6482,9 +6067,8 @@
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.3.2.tgz",
-      "integrity": "sha512-VJFWY5sfoZerQRvJrh518h3AcQt6f/yTuWn4/TRB+dqmYU0NX1qz7qM5Wfd+gOQqUzQW4gxKqKN3KpE/P3+zrA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.3.61"
       },
@@ -6494,10 +6078,9 @@
     },
     "node_modules/@vitejs/plugin-react-swc/node_modules/@swc/core": {
       "version": "1.3.66",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.66.tgz",
-      "integrity": "sha512-Hpf91kH5ly7fHkWnApwryTQryT+TO4kMMPH3WyciUSQOWLE3UuQz1PtETHQQk7PZ/b1QF0qQurJrgfBr5bSKUA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       },
@@ -6528,9 +6111,8 @@
     },
     "node_modules/@vitejs/plugin-react-swc/node_modules/@swc/helpers": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -6539,8 +6121,7 @@
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.32.2.tgz",
-      "integrity": "sha512-/+V3nB3fyeuuSeKxCfi6XmWjDIxpky7AWSkGVfaMjAk7di8igBwRsThLjultwIZdTDH1RAxpjmCXEfSqsMFZOA==",
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@bcoe/v8-coverage": "^0.2.3",
@@ -6563,8 +6144,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.32.2.tgz",
-      "integrity": "sha512-6q5yzweLnyEv5Zz1fqK5u5E83LU+gOMVBDuxBl2d2Jfx1BAp5M+rZgc5mlyqdnxquyoiOXpXmFNkcGcfFnFH3Q==",
+      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "0.32.2",
         "@vitest/utils": "0.32.2",
@@ -6576,8 +6156,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.32.2.tgz",
-      "integrity": "sha512-06vEL0C1pomOEktGoLjzZw+1Fb+7RBRhmw/06WkDrd1akkT9i12su0ku+R/0QM69dfkIL/rAIDTG+CSuQVDcKw==",
+      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "0.32.2",
         "concordance": "^5.0.4",
@@ -6590,8 +6169,7 @@
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -6604,8 +6182,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.32.2.tgz",
-      "integrity": "sha512-JwhpeH/PPc7GJX38vEfCy9LtRzf9F4er7i4OsAJyV7sjPwjj+AIR8cUgpMTWK4S3TiamzopcTyLsZDMuldoi5A==",
+      "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.0",
         "pathe": "^1.1.0",
@@ -6617,8 +6194,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.32.2.tgz",
-      "integrity": "sha512-Q/ZNILJ4ca/VzQbRM8ur3Si5Sardsh1HofatG9wsJY1RfEaw0XKP8IVax2lI1qnrk9YPuG9LA2LkZ0EI/3d4ug==",
+      "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.1.0"
       },
@@ -6628,8 +6204,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.32.2.tgz",
-      "integrity": "sha512-lnJ0T5i03j0IJaeW73hxe2AuVnZ/y1BhhCOuIcl9LIzXnbpXJT9Lrt6brwKHXLOiA7MZ6N5hSJjt0xE1dGNCzQ==",
+      "license": "MIT",
       "dependencies": {
         "diff-sequences": "^29.4.3",
         "loupe": "^2.3.6",
@@ -6817,8 +6392,7 @@
     },
     "node_modules/acorn": {
       "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6835,8 +6409,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -7160,17 +6733,15 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7230,9 +6801,8 @@
     },
     "node_modules/await-to-js": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-2.1.1.tgz",
-      "integrity": "sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -7382,14 +6952,12 @@
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
-      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "license": "MIT",
       "dependencies": {
         "is-windows": "^1.0.0"
       },
@@ -7422,8 +6990,7 @@
     },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
-      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -7661,9 +7228,8 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7678,8 +7244,7 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7820,8 +7385,7 @@
     },
     "node_modules/chai": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -7879,8 +7443,7 @@
     },
     "node_modules/check-error": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -8227,8 +7790,7 @@
     },
     "node_modules/concordance": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
-      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
+      "license": "ISC",
       "dependencies": {
         "date-time": "^3.1.0",
         "esutils": "^2.0.3",
@@ -8851,9 +8413,8 @@
     },
     "node_modules/create-check": {
       "version": "0.6.40",
-      "resolved": "https://registry.npmjs.org/create-check/-/create-check-0.6.40.tgz",
-      "integrity": "sha512-07+EtASTl5P6OUlnBWARnMt16NkVZNy6XGMA2LtQ9Te6uDi+GRD2UKoGqYR4LrISqYyfkEYNNPFd+qB3dIz3XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/app": "^4.2.1",
         "@octokit/rest": "^18.0.6",
@@ -8865,9 +8426,8 @@
     },
     "node_modules/create-check/node_modules/execa": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -8888,9 +8448,8 @@
     },
     "node_modules/create-check/node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8903,9 +8462,8 @@
     },
     "node_modules/create-check/node_modules/human-signals": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
       }
@@ -8948,9 +8506,8 @@
     },
     "node_modules/css-functions-list": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
-      "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.22"
       }
@@ -9304,8 +8861,7 @@
     },
     "node_modules/date-time": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
-      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
+      "license": "MIT",
       "dependencies": {
         "time-zone": "^1.0.0"
       },
@@ -9384,8 +8940,7 @@
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -9539,9 +9094,8 @@
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -9571,8 +9125,7 @@
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9805,9 +9358,8 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -9822,8 +9374,7 @@
     },
     "node_modules/emittery": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
-      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -9897,9 +9448,8 @@
     },
     "node_modules/env-ci": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
-      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
         "fromentries": "^1.3.2",
@@ -10089,8 +9639,7 @@
     },
     "node_modules/eslint": {
       "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -10400,8 +9949,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -10435,8 +9983,7 @@
     },
     "node_modules/espree": {
       "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -10677,8 +10224,7 @@
     },
     "node_modules/extendable-error": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
-      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="
+      "license": "MIT"
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -10745,9 +10291,8 @@
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -11176,8 +10721,6 @@
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true,
       "funding": [
         {
@@ -11192,7 +10735,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",
@@ -11268,8 +10812,7 @@
     },
     "node_modules/get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -11425,8 +10968,7 @@
     },
     "node_modules/globals": {
       "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -11474,9 +11016,8 @@
     },
     "node_modules/globjoin": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/globrex": {
       "version": "0.1.2",
@@ -11522,8 +11063,7 @@
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.6.0",
@@ -12437,9 +11977,8 @@
     },
     "node_modules/irregular-plurals": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-      "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -12859,8 +12398,7 @@
     },
     "node_modules/is-subdir": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
-      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "license": "MIT",
       "dependencies": {
         "better-path-resolve": "1.0.0"
       },
@@ -12952,8 +12490,7 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13016,8 +12553,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
@@ -13056,9 +12592,8 @@
     },
     "node_modules/java-properties": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
-      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -13273,8 +12808,7 @@
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -13427,8 +12961,7 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -13439,9 +12972,8 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -13461,9 +12993,8 @@
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -13492,9 +13023,8 @@
     },
     "node_modules/jwa": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -13503,9 +13033,8 @@
     },
     "node_modules/jws": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -13541,9 +13070,8 @@
     },
     "node_modules/known-css-properties": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
-      "integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/latest-version": {
       "version": "5.1.0",
@@ -13720,9 +13248,8 @@
     },
     "node_modules/lodash.chunk": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.curry": {
       "version": "4.1.1",
@@ -13738,39 +13265,33 @@
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -13782,20 +13303,17 @@
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
+      "license": "MIT"
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -13835,8 +13353,7 @@
     },
     "node_modules/loupe": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -13867,9 +13384,8 @@
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13932,9 +13448,8 @@
     },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -13942,8 +13457,7 @@
     },
     "node_modules/md5-hex": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
-      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
+      "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.10.0"
       },
@@ -14972,8 +14486,7 @@
     },
     "node_modules/mlly": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
-      "integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.9.0",
         "pathe": "^1.1.1",
@@ -15001,9 +14514,8 @@
     },
     "node_modules/msw": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.2.tgz",
-      "integrity": "sha512-GsW3PE/Es/a1tYThXcM8YHOZ1S1MtivcS3He/LQbbTCx3rbWJYCtWD5XXyJ53KlNPT7O1VI9sCW3xMtgFe8XpQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@mswjs/cookies": "^0.2.2",
         "@mswjs/interceptors": "^0.17.5",
@@ -15692,8 +15204,7 @@
     },
     "node_modules/outdent": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
-      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="
+      "license": "MIT"
     },
     "node_modules/outvariant": {
       "version": "1.4.0",
@@ -15729,8 +15240,7 @@
     },
     "node_modules/p-filter": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "license": "MIT",
       "dependencies": {
         "p-map": "^2.0.0"
       },
@@ -15797,8 +15307,7 @@
     },
     "node_modules/p-map": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -16254,13 +15763,11 @@
     },
     "node_modules/pathe": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q=="
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -16329,8 +15836,7 @@
     },
     "node_modules/pkg-types": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
-      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
@@ -16387,9 +15893,8 @@
     },
     "node_modules/plur": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
-      "integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "irregular-plurals": "^2.0.0"
       },
@@ -16399,8 +15904,6 @@
     },
     "node_modules/postcss": {
       "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -16415,6 +15918,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -16573,9 +16077,8 @@
     },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss-merge-idents": {
       "version": "5.1.1",
@@ -16900,15 +16403,13 @@
     },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-      "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss-safe-parser": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       },
@@ -17014,8 +16515,7 @@
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -17187,8 +16687,7 @@
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+      "license": "ISC"
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -17804,8 +17303,7 @@
     },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
-      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.5",
         "js-yaml": "^3.6.1",
@@ -17818,16 +17316,14 @@
     },
     "node_modules/read-yaml-file/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -17838,8 +17334,7 @@
     },
     "node_modules/read-yaml-file/node_modules/pify": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -19131,9 +18626,8 @@
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -19341,8 +18835,7 @@
     },
     "node_modules/spawndamnit": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
-      "integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -19350,8 +18843,7 @@
     },
     "node_modules/spawndamnit/node_modules/cross-spawn": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "license": "MIT",
       "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -19360,8 +18852,7 @@
     },
     "node_modules/spawndamnit/node_modules/lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "license": "ISC",
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -19369,8 +18860,7 @@
     },
     "node_modules/spawndamnit/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -19380,16 +18870,14 @@
     },
     "node_modules/spawndamnit/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/spawndamnit/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -19399,8 +18887,7 @@
     },
     "node_modules/spawndamnit/node_modules/yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+      "license": "ISC"
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -19713,9 +19200,8 @@
     },
     "node_modules/style-search": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/style-to-object": {
       "version": "0.4.1",
@@ -19758,9 +19244,8 @@
     },
     "node_modules/stylelint": {
       "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.9.0.tgz",
-      "integrity": "sha512-sXtAZi64CllWr6A+8ymDWnlIaYwuAa7XRmGnJxLQXFNnLjd3Izm4HAD+loKVaZ7cpK6SLxhAUX1lwPJKGCn0mg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.2.0",
         "@csstools/css-tokenizer": "^2.1.1",
@@ -19817,18 +19302,16 @@
     },
     "node_modules/stylelint-config-recommended": {
       "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
-      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "stylelint": "^15.5.0"
       }
     },
     "node_modules/stylelint-config-standard": {
       "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
-      "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "stylelint-config-recommended": "^12.0.0"
       },
@@ -19838,9 +19321,8 @@
     },
     "node_modules/stylelint-formatter-github": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-formatter-github/-/stylelint-formatter-github-1.0.1.tgz",
-      "integrity": "sha512-OSJRwzj7k/K/7JefV+g3PCN66AsMXOzng2W6AUFxvDgoXV8SRdLPqDvNmBcGOR9Y9bIGiMZS7uK83Aj7NxBCDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "create-check": "^0.6.36",
         "stylelint-formatter-pretty": "^1.1.2"
@@ -19854,9 +19336,8 @@
     },
     "node_modules/stylelint-formatter-pretty": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/stylelint-formatter-pretty/-/stylelint-formatter-pretty-1.1.4.tgz",
-      "integrity": "sha512-wgPu7UaWJO8ISiSXelp46jhtM8J/CIsrndgpUOow80v0GvyrmLrRURCFV16oKddkH0NcjlO91C7c+ef2U+siNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.0",
         "chalk": "^3.0.0",
@@ -19870,9 +19351,8 @@
     },
     "node_modules/stylelint-formatter-pretty/node_modules/chalk": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19883,42 +19363,37 @@
     },
     "node_modules/stylelint-formatter-pretty/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/stylelint-formatter-pretty/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stylelint-formatter-pretty/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/stylelint-formatter-pretty/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/stylelint-formatter-pretty/node_modules/log-symbols": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^2.4.2"
       },
@@ -19928,9 +19403,8 @@
     },
     "node_modules/stylelint-formatter-pretty/node_modules/log-symbols/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -19940,9 +19414,8 @@
     },
     "node_modules/stylelint-formatter-pretty/node_modules/log-symbols/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -19954,9 +19427,8 @@
     },
     "node_modules/stylelint-formatter-pretty/node_modules/log-symbols/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -19966,15 +19438,13 @@
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stylelint/node_modules/cosmiconfig": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -19990,9 +19460,8 @@
     },
     "node_modules/stylelint/node_modules/css-tree": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
@@ -20003,9 +19472,8 @@
     },
     "node_modules/stylelint/node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -20015,33 +19483,29 @@
     },
     "node_modules/stylelint/node_modules/import-lazy": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/stylelint/node_modules/is-plain-object": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/stylelint/node_modules/mdn-data": {
       "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/stylelint/node_modules/meow": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
@@ -20065,9 +19529,8 @@
     },
     "node_modules/stylelint/node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
         "is-core-module": "^2.5.0",
@@ -20080,9 +19543,8 @@
     },
     "node_modules/stylelint/node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -20098,18 +19560,16 @@
     },
     "node_modules/stylelint/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/stylelint/node_modules/signal-exit": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -20119,9 +19579,8 @@
     },
     "node_modules/stylelint/node_modules/type-fest": {
       "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -20131,9 +19590,8 @@
     },
     "node_modules/stylelint/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -20144,9 +19602,8 @@
     },
     "node_modules/stylelint/node_modules/yargs-parser": {
       "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -20163,9 +19620,8 @@
     },
     "node_modules/supports-hyperlinks": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -20190,8 +19646,6 @@
     },
     "node_modules/svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
     "node_modules/svgo": {
@@ -20299,9 +19753,8 @@
     },
     "node_modules/table": {
       "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -20315,9 +19768,8 @@
     },
     "node_modules/table/node_modules/ajv": {
       "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -20331,9 +19783,8 @@
     },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -20471,8 +19922,7 @@
     },
     "node_modules/time-zone": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -20506,8 +19956,7 @@
     },
     "node_modules/tinyspy": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -20694,8 +20143,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -20763,8 +20211,7 @@
     },
     "node_modules/typescript": {
       "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20792,8 +20239,7 @@
     },
     "node_modules/ufo": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
-      "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ=="
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -21201,9 +20647,8 @@
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -21764,8 +21209,7 @@
     },
     "node_modules/vite-node": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.32.2.tgz",
-      "integrity": "sha512-dTQ1DCLwl2aEseov7cfQ+kDMNJpM1ebpyMMMwWzBvLbis8Nla/6c9WQcqpPssTwS6Rp/+U6KwlIj8Eapw4bLdA==",
+      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -21786,8 +21230,7 @@
     },
     "node_modules/vitest": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.32.2.tgz",
-      "integrity": "sha512-hU8GNNuQfwuQmqTLfiKcqEhZY72Zxb7nnN07koCUNmntNxbKQnVbeIS6sqUgR3eXSlbOpit8+/gr1KpqoMgWCQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
@@ -22313,8 +21756,7 @@
     },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
-      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
+      "license": "ISC",
       "engines": {
         "node": ">=6"
       }
@@ -22698,8 +22140,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -22757,8 +22198,7 @@
         "p-debounce": "^4.0.0",
         "react-markdown": "^8.0.7",
         "react-merge-refs": "^2.0.2",
-        "remark-gfm": "^3.0.1",
-        "type-fest": "^3.12.0"
+        "remark-gfm": "^3.0.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.0.0",
@@ -22901,17 +22341,6 @@
         }
       }
     },
-    "packages/react/node_modules/type-fest": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.12.0.tgz",
-      "integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/web": {
       "name": "@markprompt/web",
       "version": "0.11.0",
@@ -23011,9 +22440,8 @@
     "packages/web/node_modules/react": {
       "name": "@preact/compat",
       "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-17.1.2.tgz",
-      "integrity": "sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "preact": "*"
       }
@@ -23021,9 +22449,8 @@
     "packages/web/node_modules/react-dom": {
       "name": "@preact/compat",
       "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-17.1.2.tgz",
-      "integrity": "sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "preact": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22757,7 +22757,8 @@
         "p-debounce": "^4.0.0",
         "react-markdown": "^8.0.7",
         "react-merge-refs": "^2.0.2",
-        "remark-gfm": "^3.0.1"
+        "remark-gfm": "^3.0.1",
+        "type-fest": "^3.12.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.0.0",
@@ -22898,6 +22899,17 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "packages/react/node_modules/type-fest": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.12.0.tgz",
+      "integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/web": {

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -164,7 +164,7 @@
   color: var(--markprompt-foreground);
   overflow: hidden;
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: 1fr auto;
   outline: 2px solid transparent;
   outline-offset: 2px;
 }
@@ -179,6 +179,22 @@
   grid-template-rows: auto 1fr;
   outline: 2px solid transparent;
   outline-offset: 2px;
+}
+
+:where(.MarkpromptViews) {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 1fr;
+}
+
+:where(.MarkpromptSearchView) {
+}
+
+:where(.MarkpromptPromptView) {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
 }
 
 :where(.MarkpromptClose) {
@@ -196,6 +212,9 @@
   transition-property: box-shadow;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
 }
 
 :where(.MarkpromptClose:hover) {
@@ -294,8 +313,7 @@
   display: none;
 }
 
-:where(.MarkpromptPromptContainer) {
-  height: 100%;
+:where(.MarkpromptAnswerContainer) {
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -822,6 +840,11 @@
   border-top: 1px solid var(--markprompt-border);
   font-size: 0.75rem;
   color: var(--markprompt-mutedForeground);
+  overflow: auto;
+}
+
+:where(.MarkpromptReferences[data-loading-state='preload']) {
+  overflow-x: hidden;
 }
 
 :where(.MarkpromptReferences p) {
@@ -853,11 +876,6 @@
 
 .MarkpromptReferences ul::-webkit-scrollbar {
   display: none;
-}
-
-.MarkpromptReferences {
-  position: relative;
-  overflow: auto;
 }
 
 .MarkpromptReferences::before,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,8 +31,7 @@
     "p-debounce": "^4.0.0",
     "react-markdown": "^8.0.7",
     "react-merge-refs": "^2.0.2",
-    "remark-gfm": "^3.0.1",
-    "type-fest": "^3.12.0"
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,8 @@
     "p-debounce": "^4.0.0",
     "react-markdown": "^8.0.7",
     "react-merge-refs": "^2.0.2",
-    "remark-gfm": "^3.0.1"
+    "remark-gfm": "^3.0.1",
+    "type-fest": "^3.12.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.0.0",

--- a/packages/react/src/Markprompt.tsx
+++ b/packages/react/src/Markprompt.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 
 import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
+import { useMarkpromptContext } from './context.js';
 import { ChatIcon } from './icons.js';
 import * as BaseMarkprompt from './primitives/headless.js';
 import { PromptView } from './PromptView.js';
@@ -16,7 +17,7 @@ import { SearchBoxTrigger } from './SearchBoxTrigger.js';
 import { SearchView } from './SearchView.js';
 import { Transition } from './Transition.js';
 import { type MarkpromptOptions } from './types.js';
-import type { Views } from './useMarkprompt.js';
+import { useMarkprompt, type Views } from './useMarkprompt.js';
 
 type MarkpromptProps = MarkpromptOptions &
   Omit<
@@ -59,10 +60,6 @@ function Markprompt(props: MarkpromptProps): ReactElement {
 
   const [open, setOpen] = useState(false);
 
-  const [activeView, setActiveView] = useState<Views>(
-    search?.enabled ? 'search' : 'prompt',
-  );
-
   useEffect(() => {
     if (!trigger?.customElement || display !== 'dialog') {
       return;
@@ -76,7 +73,6 @@ function Markprompt(props: MarkpromptProps): ReactElement {
     <BaseMarkprompt.Root
       projectKey={projectKey}
       display={display}
-      activeView={activeView}
       promptOptions={prompt}
       searchOptions={search}
       open={open}
@@ -125,11 +121,9 @@ function Markprompt(props: MarkpromptProps): ReactElement {
               )}
 
               <MarkpromptContent
-                activeView={activeView}
                 prompt={prompt}
                 references={references}
                 search={search}
-                setActiveView={setActiveView}
               />
 
               {close?.visible !== false && (
@@ -157,8 +151,6 @@ function Markprompt(props: MarkpromptProps): ReactElement {
             prompt={prompt}
             search={search}
             references={references}
-            activeView={activeView}
-            setActiveView={setActiveView}
           />
         </BaseMarkprompt.PlainContent>
       )}
@@ -167,15 +159,15 @@ function Markprompt(props: MarkpromptProps): ReactElement {
 }
 
 type MarkpromptContentProps = {
-  activeView: Views;
   prompt: MarkpromptOptions['prompt'];
   references: MarkpromptOptions['references'];
   search: MarkpromptOptions['search'];
-  setActiveView: Dispatch<SetStateAction<Views>>;
 };
 
 function MarkpromptContent(props: MarkpromptContentProps): ReactElement {
-  const { activeView, prompt, references, search, setActiveView } = props;
+  const { prompt, references, search } = props;
+
+  const { activeView, setActiveView } = useMarkpromptContext();
 
   return (
     <div className="MarkpromptViews">

--- a/packages/react/src/Markprompt.tsx
+++ b/packages/react/src/Markprompt.tsx
@@ -1,43 +1,30 @@
-import type { FileSectionReference, Source } from '@markprompt/core';
 import * as AccessibleIcon from '@radix-ui/react-accessible-icon';
-import { animated, useSpring } from '@react-spring/web';
 import Emittery from 'emittery';
 import React, {
   useEffect,
-  useRef,
   useState,
   type Dispatch,
   type ReactElement,
-  type ReactNode,
   type SetStateAction,
 } from 'react';
 
-import { Answer } from './Answer.js';
 import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
-import { useMarkpromptContext } from './context.js';
-import { Feedback } from './Feedback.js';
-import {
-  ChatIcon,
-  ChevronLeftIcon,
-  ChevronUpIcon,
-  CommandIcon,
-  CornerDownLeftIcon,
-  SearchIcon,
-  SparklesIcon,
-} from './icons.js';
+import { ChatIcon } from './icons.js';
 import * as BaseMarkprompt from './primitives/headless.js';
-import { References } from './References.js';
-import { SearchResult } from './SearchResult.js';
-import { type MarkpromptOptions, type SectionHeading } from './types.js';
-import { useToggle } from './useToggle.js';
+import { PromptView } from './PromptView.js';
+import { SearchBoxTrigger } from './SearchBoxTrigger.js';
+import { SearchView } from './SearchView.js';
+import { Transition } from './Transition.js';
+import { type MarkpromptOptions } from './types.js';
+import type { Views } from './useMarkprompt.js';
 
 type MarkpromptProps = MarkpromptOptions &
   Omit<
     BaseMarkprompt.RootProps,
+    | 'activeView'
     | 'children'
-    | 'isSearchActive'
-    | 'open'
     | 'onOpenChange'
+    | 'open'
     | 'promptOptions'
     | 'searchOptions'
   > & {
@@ -56,22 +43,25 @@ function openMarkprompt(): void {
 
 function Markprompt(props: MarkpromptProps): ReactElement {
   const {
+    close,
+    debug,
+    description,
     display = 'dialog',
     projectKey,
     prompt,
-    trigger,
+    references,
     search,
     showBranding,
     title,
-    description,
-    close,
-    debug,
+    trigger,
     ...dialogProps
   } = props;
 
   const [open, setOpen] = useState(false);
 
-  const [showSearch, toggleSearch] = useToggle(search?.enabled ?? false);
+  const [activeView, setActiveView] = useState<Views>(
+    search?.enabled ? 'search' : 'prompt',
+  );
 
   useEffect(() => {
     if (!trigger?.customElement || display !== 'dialog') {
@@ -86,7 +76,7 @@ function Markprompt(props: MarkpromptProps): ReactElement {
     <BaseMarkprompt.Root
       projectKey={projectKey}
       display={display}
-      isSearchActive={showSearch}
+      activeView={activeView}
       promptOptions={prompt}
       searchOptions={search}
       open={open}
@@ -117,41 +107,58 @@ function Markprompt(props: MarkpromptProps): ReactElement {
       )}
 
       {display === 'dialog' && (
-        <BaseMarkprompt.Portal>
-          <BaseMarkprompt.Overlay className="MarkpromptOverlay" />
-          <BaseMarkprompt.Content
-            className="MarkpromptContentDialog"
-            showBranding={showBranding}
-          >
-            <BaseMarkprompt.Title hide={title?.hide ?? true}>
-              {title?.text ?? DEFAULT_MARKPROMPT_OPTIONS.prompt!.label}
-            </BaseMarkprompt.Title>
+        <>
+          <BaseMarkprompt.Portal>
+            <BaseMarkprompt.Overlay className="MarkpromptOverlay" />
+            <BaseMarkprompt.Content
+              className="MarkpromptContentDialog"
+              showBranding={showBranding}
+            >
+              <BaseMarkprompt.Title hide={title?.hide ?? true}>
+                {title?.text ?? DEFAULT_MARKPROMPT_OPTIONS.prompt!.label}
+              </BaseMarkprompt.Title>
 
-            {description?.text && (
-              <BaseMarkprompt.Description hide={description?.hide ?? true}>
-                {description?.text}
-              </BaseMarkprompt.Description>
-            )}
+              {description?.text && (
+                <BaseMarkprompt.Description hide={description?.hide ?? true}>
+                  {description?.text}
+                </BaseMarkprompt.Description>
+              )}
 
-            <MarkpromptContent
-              {...props}
-              showSearch={showSearch}
-              toggleSearch={toggleSearch}
-              includeClose={close?.visible !== false}
-            />
-          </BaseMarkprompt.Content>
-        </BaseMarkprompt.Portal>
+              <MarkpromptContent
+                activeView={activeView}
+                prompt={prompt}
+                references={references}
+                search={search}
+                setActiveView={setActiveView}
+              />
+
+              {close?.visible !== false && (
+                <BaseMarkprompt.Close className="MarkpromptClose">
+                  <AccessibleIcon.Root
+                    label={
+                      close?.label ?? DEFAULT_MARKPROMPT_OPTIONS.close!.label!
+                    }
+                  >
+                    <kbd>Esc</kbd>
+                  </AccessibleIcon.Root>
+                </BaseMarkprompt.Close>
+              )}
+            </BaseMarkprompt.Content>
+          </BaseMarkprompt.Portal>
+        </>
       )}
+
       {display === 'plain' && (
         <BaseMarkprompt.PlainContent
           className="MarkpromptContentPlain"
           showBranding={showBranding}
         >
           <MarkpromptContent
-            {...props}
-            showSearch={showSearch}
-            toggleSearch={toggleSearch}
-            includeClose={false}
+            prompt={prompt}
+            search={search}
+            references={references}
+            activeView={activeView}
+            setActiveView={setActiveView}
           />
         </BaseMarkprompt.PlainContent>
       )}
@@ -159,397 +166,34 @@ function Markprompt(props: MarkpromptProps): ReactElement {
   );
 }
 
-type MarkpromptContentProps = Pick<
-  MarkpromptProps,
-  'close' | 'feedback' | 'prompt' | 'references' | 'search'
-> & {
-  showSearch?: boolean;
-  toggleSearch?: () => void;
-  includeClose?: boolean;
+type MarkpromptContentProps = {
+  activeView: Views;
+  prompt: MarkpromptOptions['prompt'];
+  references: MarkpromptOptions['references'];
+  search: MarkpromptOptions['search'];
+  setActiveView: Dispatch<SetStateAction<Views>>;
 };
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export const noop = (): void => {};
 
 function MarkpromptContent(props: MarkpromptContentProps): ReactElement {
-  const {
-    close,
-    feedback,
-    includeClose = true,
-    prompt,
-    references,
-    search,
-    showSearch = false,
-    toggleSearch = noop,
-  } = props;
+  const { activeView, prompt, references, search, setActiveView } = props;
 
   return (
-    <>
-      <BaseMarkprompt.Form className="MarkpromptForm">
-        <BaseMarkprompt.Prompt
-          className="MarkpromptPrompt"
-          placeholder={
-            prompt?.placeholder ??
-            (search?.enabled
-              ? 'Search or ask a question…'
-              : DEFAULT_MARKPROMPT_OPTIONS.prompt!.label)
-          }
-          labelClassName="MarkpromptPromptLabel"
-          label={
-            <AccessibleIcon.Root
-              label={prompt?.label ?? DEFAULT_MARKPROMPT_OPTIONS.prompt!.label!}
-            >
-              <SearchIcon className="MarkpromptSearchIcon" />
-            </AccessibleIcon.Root>
-          }
-        />
-
-        {includeClose && (
-          <BaseMarkprompt.Close className="MarkpromptClose">
-            <AccessibleIcon.Root
-              label={close?.label ?? DEFAULT_MARKPROMPT_OPTIONS.close!.label!}
-            >
-              <kbd>Esc</kbd>
-            </AccessibleIcon.Root>
-          </BaseMarkprompt.Close>
-        )}
-      </BaseMarkprompt.Form>
-
-      <AnswerOrSearchResults
-        feedback={feedback}
-        search={search}
-        references={references}
-        showSearch={showSearch}
-        promptCTA={prompt?.cta}
-        toggleSearchAnswer={toggleSearch}
-      />
-    </>
-  );
-}
-
-type AnswerOrSearchResultsProps = {
-  feedback?: MarkpromptOptions['feedback'];
-  promptCTA?: string;
-  references: MarkpromptOptions['references'];
-  search?: MarkpromptOptions['search'];
-  showSearch: boolean;
-  toggleSearchAnswer: () => void;
-};
-
-function AnswerOrSearchResults(
-  props: AnswerOrSearchResultsProps,
-): ReactElement {
-  const {
-    feedback,
-    promptCTA,
-    references,
-    search,
-    showSearch,
-    toggleSearchAnswer,
-  } = props;
-
-  if (!search?.enabled) {
-    return (
-      <AnswerContainer
-        feedback={feedback}
-        isSearchEnabled={search?.enabled}
-        references={references}
-        toggleSearchAnswer={toggleSearchAnswer}
-      />
-    );
-  }
-
-  return (
-    <div style={{ position: 'relative', overflowY: 'auto' }}>
-      <Transition isVisible={showSearch}>
-        <SearchResultsContainer
-          getHref={search?.getHref}
-          showSearch={showSearch}
-          promptCTA={promptCTA}
-          toggleSearchAnswer={toggleSearchAnswer}
+    <div className="MarkpromptViews">
+      <Transition isVisible={activeView === 'search'}>
+        <SearchView
+          handleViewChange={() => setActiveView('prompt')}
+          prompt={prompt}
+          search={search}
         />
       </Transition>
-      <Transition isVisible={!showSearch} isFlipped>
-        <AnswerContainer
-          feedback={feedback}
-          isSearchEnabled={search?.enabled}
+      <Transition isVisible={activeView === 'prompt'} isFlipped>
+        <PromptView
+          handleViewChange={() => setActiveView('search')}
+          prompt={prompt}
+          search={search}
           references={references}
-          toggleSearchAnswer={toggleSearchAnswer}
         />
       </Transition>
-    </div>
-  );
-}
-
-type TransitionProps = {
-  isVisible: boolean;
-  isFlipped?: boolean;
-  children: ReactNode;
-};
-
-const Transition = (props: TransitionProps): ReactElement => {
-  const { isVisible, isFlipped, children } = props;
-
-  const [display, setDisplay] = useState(isVisible ? 'block' : 'none');
-
-  const styles = useSpring({
-    opacity: isVisible ? 1 : 0,
-    x: isVisible ? '0%' : isFlipped ? '100%' : '-100%',
-    config: {
-      tension: 800,
-      friction: 60,
-    },
-    onStart: () => {
-      if (!isVisible) return;
-      setDisplay('block');
-    },
-    onRest: () => {
-      if (isVisible) return;
-      setDisplay('none');
-    },
-  });
-
-  return (
-    <animated.div
-      style={{
-        position: 'absolute',
-        inset: 0,
-        display,
-        ...styles,
-      }}
-    >
-      {children}
-    </animated.div>
-  );
-};
-
-interface SearchBoxTriggerProps {
-  trigger: MarkpromptOptions['trigger'];
-  open: boolean;
-  setOpen: Dispatch<SetStateAction<boolean>>;
-}
-
-function SearchBoxTrigger(props: SearchBoxTriggerProps): ReactElement {
-  const { trigger, setOpen, open } = props;
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (open) return;
-      if (
-        (event.key === 'Enter' && event.ctrlKey) ||
-        (event.key === 'Enter' && event.metaKey)
-      ) {
-        event.preventDefault();
-        setOpen(true);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [open, setOpen]);
-
-  return (
-    <BaseMarkprompt.DialogTrigger className="MarkpromptSearchBoxTrigger">
-      <AccessibleIcon.Root
-        label={trigger?.label ?? DEFAULT_MARKPROMPT_OPTIONS.trigger!.label!}
-      >
-        <span className="MarkpromptSearchBoxTriggerContent">
-          <span className="MarkpromptSearchBoxTriggerText">
-            <SearchIcon width={16} height={16} />{' '}
-            {trigger?.placeholder || 'Search'}{' '}
-          </span>
-          <kbd>
-            {navigator.platform.indexOf('Mac') === 0 ||
-            navigator.platform === 'iPhone' ? (
-              <CommandIcon className="MarkpromptKeyboardKey" />
-            ) : (
-              <ChevronUpIcon className="MarkpromptKeyboardKey" />
-            )}
-            <CornerDownLeftIcon className="MarkpromptKeyboardKey" />
-          </kbd>
-        </span>
-      </AccessibleIcon.Root>
-    </BaseMarkprompt.DialogTrigger>
-  );
-}
-
-type SearchResultsContainerProps = {
-  getHref?: (reference: FileSectionReference) => string;
-  showSearch: boolean;
-  promptCTA?: string;
-  toggleSearchAnswer: () => void;
-};
-
-function SearchResultsContainer(
-  props: SearchResultsContainerProps,
-): ReactElement {
-  const { showSearch, promptCTA, toggleSearchAnswer, getHref } = props;
-
-  const btn = useRef<HTMLButtonElement>(null);
-
-  const {
-    abort,
-    submitPrompt,
-    state,
-    searchResults,
-    prompt,
-    activeSearchResult,
-    updateActiveSearchResult,
-  } = useMarkpromptContext();
-
-  const hasActiveSearchResult = activeSearchResult !== undefined;
-
-  useEffect(() => {
-    if (hasActiveSearchResult) {
-      btn.current?.blur();
-    }
-  }, [hasActiveSearchResult]);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (
-        (event.key === 'Enter' && event.ctrlKey) ||
-        (event.key === 'Enter' && event.metaKey)
-      ) {
-        event.preventDefault();
-        if (showSearch) submitPrompt();
-        toggleSearchAnswer();
-      }
-
-      if (event.key === 'ArrowUp') {
-        if (activeSearchResult === 'markprompt-result-0') {
-          btn.current?.focus();
-          updateActiveSearchResult(undefined);
-        }
-      }
-
-      if (event.key === 'ArrowDown') {
-        if (searchResults.length > 0 && activeSearchResult === undefined) {
-          updateActiveSearchResult('markprompt-result-0');
-          const el = document.querySelector('#markprompt-prompt');
-          if (el instanceof HTMLInputElement) el.focus();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [
-    activeSearchResult,
-    searchResults,
-    showSearch,
-    submitPrompt,
-    toggleSearchAnswer,
-    updateActiveSearchResult,
-  ]);
-
-  return (
-    <div className="MarkpromptSearchResultsContainer">
-      <button
-        ref={btn}
-        className="MarkpromptSearchAnswerButton"
-        onClick={() => {
-          abort();
-          toggleSearchAnswer();
-          submitPrompt();
-        }}
-        onMouseOver={() => {
-          btn.current?.focus();
-          updateActiveSearchResult(undefined);
-        }}
-      >
-        <span aria-hidden className="MarkpromptSearchResultIconWrapper">
-          <SparklesIcon focusable={false} className="MarkpromptSearchIcon" />
-        </span>
-        <span>{promptCTA || DEFAULT_MARKPROMPT_OPTIONS.prompt!.cta!}</span>
-        <kbd>
-          {navigator.platform.indexOf('Mac') === 0 ||
-          navigator.platform === 'iPhone' ? (
-            <CommandIcon className="MarkpromptKeyboardKey" />
-          ) : (
-            <ChevronUpIcon className="MarkpromptKeyboardKey" />
-          )}
-          <CornerDownLeftIcon className="MarkpromptKeyboardKey" />
-        </kbd>
-      </button>
-      {state === 'done' && searchResults.length === 0 && (
-        <div className="MarkpromptNoSearchResults">
-          <p>
-            No results for “<span>{prompt}</span>”
-          </p>
-        </div>
-      )}
-
-      {searchResults.length > 0 && (
-        <BaseMarkprompt.SearchResults
-          className="MarkpromptSearchResults"
-          SearchResultComponent={(props) => (
-            <SearchResult {...props} getHref={getHref} />
-          )}
-        />
-      )}
-    </div>
-  );
-}
-
-type AnswerContainerProps = {
-  feedback?: MarkpromptOptions['feedback'];
-  isSearchEnabled?: boolean;
-  references: MarkpromptOptions['references'];
-  toggleSearchAnswer: () => void;
-};
-
-function AnswerContainer({
-  isSearchEnabled,
-  references,
-  feedback,
-  toggleSearchAnswer,
-}: AnswerContainerProps): ReactElement {
-  const { abort, state } = useMarkpromptContext();
-
-  return (
-    <div className="MarkpromptPromptContainer">
-      {isSearchEnabled && (
-        <button
-          className="MarkpromptBackButton"
-          onClick={() => {
-            abort();
-            toggleSearchAnswer();
-          }}
-        >
-          <span aria-hidden>
-            <ChevronLeftIcon className="MarkpromptHighlightedIcon" />
-          </span>
-          <span>Back to search</span>
-        </button>
-      )}
-
-      <BaseMarkprompt.AutoScroller className="MarkpromptAutoScroller">
-        <Answer />
-        {feedback?.enabled && state === 'done' && (
-          <Feedback
-            className="MarkpromptPromptFeedback"
-            heading={feedback?.heading}
-            confirmationMessage={feedback?.confirmationMessage}
-          />
-        )}
-      </BaseMarkprompt.AutoScroller>
-
-      <References
-        loadingText={references?.loadingText}
-        // referencesText is for backwards compatibility
-        heading={references?.heading || references?.referencesText}
-        getHref={references?.getHref}
-        getLabel={references?.getLabel}
-        // Backwards compatibility
-        transformReferenceId={references?.transformReferenceId}
-      />
     </div>
   );
 }

--- a/packages/react/src/MarkpromptForm.tsx
+++ b/packages/react/src/MarkpromptForm.tsx
@@ -1,0 +1,29 @@
+import * as AccessibleIcon from '@radix-ui/react-accessible-icon';
+import React, { type ComponentPropsWithoutRef, type ReactElement } from 'react';
+
+import { SearchIcon } from './icons.js';
+import * as BaseMarkprompt from './primitives/headless.js';
+
+interface MarkpromptFormProps {
+  label: string;
+  placeholder: string;
+  inputProps?: ComponentPropsWithoutRef<typeof BaseMarkprompt.Prompt>;
+}
+export function MarkpromptForm(props: MarkpromptFormProps): ReactElement {
+  const { placeholder, label } = props;
+
+  return (
+    <BaseMarkprompt.Form className="MarkpromptForm">
+      <BaseMarkprompt.Prompt
+        className="MarkpromptPrompt"
+        placeholder={placeholder}
+        labelClassName="MarkpromptPromptLabel"
+        label={
+          <AccessibleIcon.Root label={label}>
+            <SearchIcon className="MarkpromptSearchIcon" />
+          </AccessibleIcon.Root>
+        }
+      />
+    </BaseMarkprompt.Form>
+  );
+}

--- a/packages/react/src/MarkpromptForm.tsx
+++ b/packages/react/src/MarkpromptForm.tsx
@@ -10,11 +10,12 @@ interface MarkpromptFormProps {
   inputProps?: ComponentPropsWithoutRef<typeof BaseMarkprompt.Prompt>;
 }
 export function MarkpromptForm(props: MarkpromptFormProps): ReactElement {
-  const { placeholder, label } = props;
+  const { inputProps, label, placeholder } = props;
 
   return (
     <BaseMarkprompt.Form className="MarkpromptForm">
       <BaseMarkprompt.Prompt
+        {...inputProps}
         className="MarkpromptPrompt"
         placeholder={placeholder}
         labelClassName="MarkpromptPromptLabel"

--- a/packages/react/src/PromptView.tsx
+++ b/packages/react/src/PromptView.tsx
@@ -72,7 +72,6 @@ function AnswerContainer({
 
       <References
         loadingText={references?.loadingText}
-        referencesText={references?.referencesText}
         transformReferenceId={references?.transformReferenceId}
       />
     </div>

--- a/packages/react/src/PromptView.tsx
+++ b/packages/react/src/PromptView.tsx
@@ -1,0 +1,80 @@
+import React, { type ReactElement } from 'react';
+
+import { Answer } from './Answer.js';
+import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
+import { useMarkpromptContext } from './context.js';
+import { ChevronLeftIcon } from './icons.js';
+import { MarkpromptForm } from './MarkpromptForm.js';
+import * as BaseMarkprompt from './primitives/headless.js';
+import { References } from './References.js';
+import { type MarkpromptOptions } from './types.js';
+
+interface PromptViewProps {
+  handleViewChange?: () => void;
+  prompt: MarkpromptOptions['prompt'];
+  references: MarkpromptOptions['references'];
+  search?: MarkpromptOptions['search'];
+}
+
+export function PromptView(props: PromptViewProps): ReactElement {
+  const { prompt, references, search, handleViewChange } = props;
+  return (
+    <div className="MarkpromptPromptView">
+      <MarkpromptForm
+        label={prompt?.label ?? DEFAULT_MARKPROMPT_OPTIONS.prompt!.label!}
+        placeholder={
+          prompt?.placeholder ?? DEFAULT_MARKPROMPT_OPTIONS.prompt!.placeholder!
+        }
+      />
+
+      <AnswerContainer
+        handleViewChange={handleViewChange}
+        isSearchEnabled={search?.enabled}
+        references={references}
+      />
+    </div>
+  );
+}
+
+interface AnswerContainerProps {
+  handleViewChange?: () => void;
+  isSearchEnabled?: boolean;
+  references: MarkpromptOptions['references'];
+}
+
+function AnswerContainer({
+  handleViewChange,
+  isSearchEnabled,
+  references,
+}: AnswerContainerProps): ReactElement {
+  const { abort } = useMarkpromptContext();
+
+  return (
+    <div className="MarkpromptAnswerContainer">
+      {isSearchEnabled && (
+        <button
+          className="MarkpromptBackButton"
+          onClick={() => {
+            abort();
+            handleViewChange?.();
+          }}
+        >
+          <span aria-hidden>
+            <ChevronLeftIcon className="MarkpromptHighlightedIcon" />
+          </span>
+          <span>Back to search</span>
+        </button>
+      )}
+
+      <BaseMarkprompt.AutoScroller className="MarkpromptAutoScroller">
+        <Answer />
+      </BaseMarkprompt.AutoScroller>
+
+      <References
+        loadingText={references?.loadingText}
+        referencesText={references?.referencesText}
+        transformReferenceId={references?.transformReferenceId}
+      />
+    </div>
+  );
+}

--- a/packages/react/src/References.tsx
+++ b/packages/react/src/References.tsx
@@ -67,12 +67,13 @@ type ReferencesProps = {
 
 const References = (props: ReferencesProps): ReactElement | null => {
   const {
-    loadingText = DEFAULT_MARKPROMPT_OPTIONS.references!.loadingText!,
-    heading = DEFAULT_MARKPROMPT_OPTIONS.references!.heading,
     getHref,
     getLabel,
+    heading = DEFAULT_MARKPROMPT_OPTIONS.references!.heading,
+    loadingText = DEFAULT_MARKPROMPT_OPTIONS.references!.loadingText!,
     transformReferenceId,
   } = props;
+
   const { references, state } = useMarkpromptContext();
   const [ref, { height }] = useElementSize<HTMLDivElement>();
 

--- a/packages/react/src/References.tsx
+++ b/packages/react/src/References.tsx
@@ -3,8 +3,8 @@ import { animated, useSpring } from '@react-spring/web';
 import React, { useCallback, useMemo, type ReactElement } from 'react';
 
 import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
-import { useMarkpromptContext } from './index.js';
 import * as Markprompt from './index.js';
+import { useMarkpromptContext } from './index.js';
 import { useElementSize } from './useElementSize.js';
 
 type ReferenceProps = {
@@ -73,7 +73,7 @@ const References = (props: ReferencesProps): ReactElement | null => {
     getLabel,
     transformReferenceId,
   } = props;
-  const { state, references } = useMarkpromptContext();
+  const { references, state } = useMarkpromptContext();
   const [ref, { height }] = useElementSize<HTMLDivElement>();
 
   const ReferenceComponent = useCallback(

--- a/packages/react/src/SearchBoxTrigger.tsx
+++ b/packages/react/src/SearchBoxTrigger.tsx
@@ -1,0 +1,75 @@
+import * as AccessibleIcon from '@radix-ui/react-accessible-icon';
+import React, {
+  useEffect,
+  type Dispatch,
+  type ReactElement,
+  type SetStateAction,
+} from 'react';
+
+import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
+import {
+  ChevronUpIcon,
+  CommandIcon,
+  CornerDownLeftIcon,
+  SearchIcon,
+} from './icons.js';
+import * as BaseMarkprompt from './primitives/headless.js';
+import { type MarkpromptOptions } from './types.js';
+
+interface SearchBoxTriggerProps {
+  trigger: MarkpromptOptions['trigger'];
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+/**
+ * A button that can be used to open the Markprompt dialog, styled as a search
+ * input, displaying a keyboard shortcut. This trigger is relatively positioned
+ * in the container where Markprompt is rendered.
+ */
+export function SearchBoxTrigger(props: SearchBoxTriggerProps): ReactElement {
+  const { trigger, setOpen, open } = props;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (open) return;
+      if (
+        (event.key === 'Enter' && event.ctrlKey) ||
+        (event.key === 'Enter' && event.metaKey)
+      ) {
+        event.preventDefault();
+        setOpen(true);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, setOpen]);
+
+  return (
+    <BaseMarkprompt.DialogTrigger className="MarkpromptSearchBoxTrigger">
+      <AccessibleIcon.Root
+        label={trigger?.label ?? DEFAULT_MARKPROMPT_OPTIONS.trigger!.label!}
+      >
+        <span className="MarkpromptSearchBoxTriggerContent">
+          <span className="MarkpromptSearchBoxTriggerText">
+            <SearchIcon width={16} height={16} />{' '}
+            {trigger?.placeholder || 'Search'}{' '}
+          </span>
+          <kbd>
+            {navigator.platform.indexOf('Mac') === 0 ||
+            navigator.platform === 'iPhone' ? (
+              <CommandIcon className="MarkpromptKeyboardKey" />
+            ) : (
+              <ChevronUpIcon className="MarkpromptKeyboardKey" />
+            )}
+            <CornerDownLeftIcon className="MarkpromptKeyboardKey" />
+          </kbd>
+        </span>
+      </AccessibleIcon.Root>
+    </BaseMarkprompt.DialogTrigger>
+  );
+}

--- a/packages/react/src/SearchView.tsx
+++ b/packages/react/src/SearchView.tsx
@@ -35,7 +35,7 @@ export function SearchView(props: SearchViewProps): ReactElement {
     string | undefined
   >();
 
-  const { activeView, searchResults, searchQuery } = useMarkpromptContext();
+  const { searchResults, searchQuery } = useMarkpromptContext();
 
   useEffect(() => {
     // if the search query changes, unset the active search result
@@ -50,8 +50,6 @@ export function SearchView(props: SearchViewProps): ReactElement {
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
-      if (activeView !== 'search') return;
-
       switch (event.key) {
         case 'ArrowDown': {
           if (!activeSearchResult) return;
@@ -100,7 +98,7 @@ export function SearchView(props: SearchViewProps): ReactElement {
         }
       }
     },
-    [activeSearchResult, activeView, searchResults.length],
+    [activeSearchResult, searchResults.length],
   );
 
   return (

--- a/packages/react/src/SearchView.tsx
+++ b/packages/react/src/SearchView.tsx
@@ -144,13 +144,10 @@ function SearchResultsContainer(
   const { abort, submitPrompt, state, searchResults, prompt } =
     useMarkpromptContext();
 
-  const hasActiveSearchResult = activeSearchResult !== undefined;
-
   useEffect(() => {
-    if (hasActiveSearchResult) {
-      btn.current?.blur();
-    }
-  }, [hasActiveSearchResult]);
+    if (!activeSearchResult) return;
+    btn.current?.blur();
+  }, [activeSearchResult]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -192,6 +189,22 @@ function SearchResultsContainer(
     setActiveSearchResult,
   ]);
 
+  useEffect(() => {
+    if (!activeSearchResult) {
+      return;
+    }
+
+    const element = document.getElementById(activeSearchResult);
+    if (!element) {
+      return;
+    }
+
+    element.focus();
+    element.scrollIntoView({
+      block: 'nearest',
+    });
+  }, [activeSearchResult, searchResults]);
+
   return (
     <div className="MarkpromptSearchResultsContainer">
       <button
@@ -210,7 +223,9 @@ function SearchResultsContainer(
         <span aria-hidden className="MarkpromptSearchResultIconWrapper">
           <SparklesIcon focusable={false} className="MarkpromptSearchIcon" />
         </span>
+
         <span>{promptCTA || DEFAULT_MARKPROMPT_OPTIONS.prompt!.cta!}</span>
+
         <kbd>
           {navigator.platform.indexOf('Mac') === 0 ||
           navigator.platform === 'iPhone' ? (
@@ -221,6 +236,7 @@ function SearchResultsContainer(
           <CornerDownLeftIcon className="MarkpromptKeyboardKey" />
         </kbd>
       </button>
+
       {state === 'done' && searchResults.length === 0 && (
         <div className="MarkpromptNoSearchResults">
           <p>
@@ -232,9 +248,18 @@ function SearchResultsContainer(
       {searchResults.length > 0 && (
         <BaseMarkprompt.SearchResults
           className="MarkpromptSearchResults"
-          SearchResultComponent={(props) => (
-            <SearchResult {...props} getHref={getResultHref} />
-          )}
+          SearchResultComponent={({ index, ...rest }) => {
+            const id = `markprompt-result-${index}`;
+            return (
+              <SearchResult
+                {...rest}
+                id={id}
+                getHref={getResultHref}
+                onMouseOver={() => setActiveSearchResult(id)}
+                aria-selected={id === activeSearchResult}
+              />
+            );
+          }}
         />
       )}
     </div>

--- a/packages/react/src/SearchView.tsx
+++ b/packages/react/src/SearchView.tsx
@@ -35,7 +35,18 @@ export function SearchView(props: SearchViewProps): ReactElement {
     string | undefined
   >();
 
-  const { activeView, searchResults } = useMarkpromptContext();
+  const { activeView, searchResults, searchQuery } = useMarkpromptContext();
+
+  useEffect(() => {
+    // if the search query changes, unset the active search result
+    setActiveSearchResult(undefined);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    // if the search results change, set the active search result to the first result
+    if (searchResults.length === 0) return;
+    setActiveSearchResult('markprompt-result-0');
+  }, [searchResults]);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
@@ -141,7 +152,7 @@ function SearchResultsContainer(
 
   const btn = useRef<HTMLButtonElement>(null);
 
-  const { abort, submitPrompt, state, searchResults, prompt } =
+  const { abort, searchQuery, searchResults, state, submitPrompt } =
     useMarkpromptContext();
 
   useEffect(() => {
@@ -240,7 +251,7 @@ function SearchResultsContainer(
       {state === 'done' && searchResults.length === 0 && (
         <div className="MarkpromptNoSearchResults">
           <p>
-            No results for “<span>{prompt}</span>”
+            No results for “<span>{searchQuery}</span>”
           </p>
         </div>
       )}

--- a/packages/react/src/SearchView.tsx
+++ b/packages/react/src/SearchView.tsx
@@ -111,7 +111,7 @@ export function SearchView(props: SearchViewProps): ReactElement {
 
       <SearchResultsContainer
         activeSearchResult={activeSearchResult}
-        getResultHref={search?.getResultHref}
+        getHref={search?.getHref}
         handleViewChange={handleViewChange}
         promptCTA={prompt?.cta}
         setActiveSearchResult={setActiveSearchResult}
@@ -125,7 +125,7 @@ interface SearchResultsContainerProps {
   setActiveSearchResult: Dispatch<SetStateAction<string | undefined>>;
   handleViewChange: () => void;
   promptCTA?: string;
-  getResultHref?: NonNullable<MarkpromptOptions['search']>['getResultHref'];
+  getHref?: NonNullable<MarkpromptOptions['search']>['getHref'];
 }
 
 function SearchResultsContainer(
@@ -133,7 +133,7 @@ function SearchResultsContainer(
 ): ReactElement {
   const {
     activeSearchResult,
-    getResultHref,
+    getHref,
     handleViewChange,
     promptCTA,
     setActiveSearchResult,
@@ -254,7 +254,7 @@ function SearchResultsContainer(
               <SearchResult
                 {...rest}
                 id={id}
-                getHref={getResultHref}
+                getHref={getHref}
                 onMouseOver={() => setActiveSearchResult(id)}
                 aria-selected={id === activeSearchResult}
               />

--- a/packages/react/src/SearchView.tsx
+++ b/packages/react/src/SearchView.tsx
@@ -1,0 +1,242 @@
+import React, {
+  useEffect,
+  useRef,
+  type ReactElement,
+  useCallback,
+  type KeyboardEventHandler,
+  type SetStateAction,
+  type Dispatch,
+  useMemo,
+} from 'react';
+
+import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
+import { useMarkpromptContext } from './context.js';
+import {
+  ChevronUpIcon,
+  CommandIcon,
+  CornerDownLeftIcon,
+  SparklesIcon,
+} from './icons.js';
+import { MarkpromptForm } from './MarkpromptForm.js';
+import * as BaseMarkprompt from './primitives/headless.js';
+import { SearchResult } from './SearchResult.js';
+import { type MarkpromptOptions } from './types.js';
+
+interface SearchViewProps {
+  prompt?: MarkpromptOptions['prompt'];
+  search?: MarkpromptOptions['search'];
+  handleViewChange: () => void;
+}
+
+export function SearchView(props: SearchViewProps): ReactElement {
+  const { prompt, search, handleViewChange } = props;
+
+  const [activeSearchResult, setActiveSearchResult] = React.useState<
+    string | undefined
+  >();
+
+  const { activeView, searchResults } = useMarkpromptContext();
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      if (activeView !== 'search') return;
+
+      switch (event.key) {
+        case 'ArrowDown': {
+          if (!activeSearchResult) return;
+          if (activeSearchResult.endsWith(`${searchResults.length - 1}`)) {
+            return;
+          }
+          event.preventDefault();
+          const nextActiveSearchResult = activeSearchResult.replace(
+            /\d+$/,
+            (match) => String(Number(match) + 1),
+          );
+          setActiveSearchResult(nextActiveSearchResult);
+          const el: HTMLAnchorElement | null = document.querySelector(
+            `#${nextActiveSearchResult} > a`,
+          );
+          if (!el) return;
+          break;
+        }
+        case 'ArrowUp': {
+          if (!activeSearchResult) return;
+          if (activeSearchResult.endsWith('0')) return;
+          event.preventDefault();
+          const nextActiveSearchResult = activeSearchResult.replace(
+            /\d+$/,
+            (match) => String(Number(match) - 1),
+          );
+          setActiveSearchResult(nextActiveSearchResult);
+          const el: HTMLAnchorElement | null = document.querySelector(
+            `#${nextActiveSearchResult} > a`,
+          );
+          if (!el) return;
+          break;
+        }
+        case 'Enter': {
+          if (event.ctrlKey || event.metaKey) return;
+          if (!activeSearchResult) return;
+          event.preventDefault();
+          // assumption here is that the search result will always contain an a element
+          const el: HTMLAnchorElement | null = document.querySelector(
+            `#${activeSearchResult} a`,
+          );
+          // todo: reset search query and result
+          if (!el) return;
+          el?.click();
+          break;
+        }
+      }
+    },
+    [activeSearchResult, activeView, searchResults.length],
+  );
+
+  return (
+    <div className="MarkpromptSearchView">
+      <MarkpromptForm
+        label={search?.label ?? DEFAULT_MARKPROMPT_OPTIONS.search!.label!}
+        placeholder={
+          search?.placeholder ?? DEFAULT_MARKPROMPT_OPTIONS.search!.placeholder!
+        }
+        inputProps={useMemo(
+          () => ({
+            onKeyDown: handleKeyDown,
+            'aria-controls': 'markprompt-search-results',
+            'aria-activedescendant': activeSearchResult,
+          }),
+          [activeSearchResult, handleKeyDown],
+        )}
+      />
+
+      <SearchResultsContainer
+        activeSearchResult={activeSearchResult}
+        getResultHref={search?.getResultHref}
+        handleViewChange={handleViewChange}
+        promptCTA={prompt?.cta}
+        setActiveSearchResult={setActiveSearchResult}
+      />
+    </div>
+  );
+}
+
+interface SearchResultsContainerProps {
+  activeSearchResult?: string;
+  setActiveSearchResult: Dispatch<SetStateAction<string | undefined>>;
+  handleViewChange: () => void;
+  promptCTA?: string;
+  getResultHref?: NonNullable<MarkpromptOptions['search']>['getResultHref'];
+}
+
+function SearchResultsContainer(
+  props: SearchResultsContainerProps,
+): ReactElement {
+  const {
+    activeSearchResult,
+    getResultHref,
+    handleViewChange,
+    promptCTA,
+    setActiveSearchResult,
+  } = props;
+
+  const btn = useRef<HTMLButtonElement>(null);
+
+  const { abort, submitPrompt, state, searchResults, prompt } =
+    useMarkpromptContext();
+
+  const hasActiveSearchResult = activeSearchResult !== undefined;
+
+  useEffect(() => {
+    if (hasActiveSearchResult) {
+      btn.current?.blur();
+    }
+  }, [hasActiveSearchResult]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (
+        (event.key === 'Enter' && event.ctrlKey) ||
+        (event.key === 'Enter' && event.metaKey)
+      ) {
+        event.preventDefault();
+        submitPrompt();
+        handleViewChange();
+      }
+
+      if (event.key === 'ArrowUp') {
+        if (activeSearchResult === 'markprompt-result-0') {
+          btn.current?.focus();
+          setActiveSearchResult(undefined);
+        }
+      }
+
+      if (event.key === 'ArrowDown') {
+        if (searchResults.length > 0 && activeSearchResult === undefined) {
+          setActiveSearchResult('markprompt-result-0');
+          const el = document.querySelector('#markprompt-prompt');
+          if (el instanceof HTMLInputElement) el.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    activeSearchResult,
+    searchResults,
+    submitPrompt,
+    handleViewChange,
+    setActiveSearchResult,
+  ]);
+
+  return (
+    <div className="MarkpromptSearchResultsContainer">
+      <button
+        ref={btn}
+        className="MarkpromptSearchAnswerButton"
+        onClick={() => {
+          abort();
+          handleViewChange();
+          submitPrompt();
+        }}
+        onMouseOver={() => {
+          btn.current?.focus();
+          setActiveSearchResult(undefined);
+        }}
+      >
+        <span aria-hidden className="MarkpromptSearchResultIconWrapper">
+          <SparklesIcon focusable={false} className="MarkpromptSearchIcon" />
+        </span>
+        <span>{promptCTA || DEFAULT_MARKPROMPT_OPTIONS.prompt!.cta!}</span>
+        <kbd>
+          {navigator.platform.indexOf('Mac') === 0 ||
+          navigator.platform === 'iPhone' ? (
+            <CommandIcon className="MarkpromptKeyboardKey" />
+          ) : (
+            <ChevronUpIcon className="MarkpromptKeyboardKey" />
+          )}
+          <CornerDownLeftIcon className="MarkpromptKeyboardKey" />
+        </kbd>
+      </button>
+      {state === 'done' && searchResults.length === 0 && (
+        <div className="MarkpromptNoSearchResults">
+          <p>
+            No results for “<span>{prompt}</span>”
+          </p>
+        </div>
+      )}
+
+      {searchResults.length > 0 && (
+        <BaseMarkprompt.SearchResults
+          className="MarkpromptSearchResults"
+          SearchResultComponent={(props) => (
+            <SearchResult {...props} getHref={getResultHref} />
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/Transition.tsx
+++ b/packages/react/src/Transition.tsx
@@ -1,0 +1,43 @@
+import { animated, useSpring } from '@react-spring/web';
+import React, { useState, type ReactElement, type ReactNode } from 'react';
+
+type TransitionProps = {
+  isVisible: boolean;
+  isFlipped?: boolean;
+  children: ReactNode;
+};
+export const Transition = (props: TransitionProps): ReactElement => {
+  const { isVisible, isFlipped, children } = props;
+
+  const [display, setDisplay] = useState(isVisible ? 'block' : 'none');
+
+  const styles = useSpring({
+    opacity: isVisible ? 1 : 0,
+    x: isVisible ? '0%' : isFlipped ? '100%' : '-100%',
+    config: {
+      tension: 800,
+      friction: 60,
+    },
+    onStart: () => {
+      if (!isVisible) return;
+      setDisplay('block');
+    },
+    onRest: () => {
+      if (isVisible) return;
+      setDisplay('none');
+    },
+  });
+
+  return (
+    <animated.div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display,
+        ...styles,
+      }}
+    >
+      {children}
+    </animated.div>
+  );
+};

--- a/packages/react/src/constants.tsx
+++ b/packages/react/src/constants.tsx
@@ -2,14 +2,9 @@ import {
   DEFAULT_SUBMIT_PROMPT_OPTIONS,
   DEFAULT_SUBMIT_SEARCH_QUERY_OPTIONS,
   type FileSectionReference,
-  type Source,
 } from '@markprompt/core';
 
-import type { MarkpromptOptions, SectionHeading } from './types.js';
-
-const capitalize = (text: string): string => {
-  return text.charAt(0).toUpperCase() + text.slice(1);
-};
+import type { MarkpromptOptions } from './types.js';
 
 const removeFileExtension = (fileName: string): string => {
   const lastDotIndex = fileName.lastIndexOf('.');
@@ -53,6 +48,7 @@ export const DEFAULT_MARKPROMPT_OPTIONS: MarkpromptOptions = {
   display: 'dialog',
   close: {
     label: 'Close Markprompt',
+    visible: true,
   },
   description: {
     hide: true,
@@ -77,8 +73,11 @@ export const DEFAULT_MARKPROMPT_OPTIONS: MarkpromptOptions = {
   },
   search: {
     ...DEFAULT_SUBMIT_SEARCH_QUERY_OPTIONS,
+    cta: 'Search docs…',
     enabled: false,
     getHref: defaultGetHref,
+    label: 'Search docs…',
+    placeholder: 'Search docs…',
   },
   trigger: {
     label: 'Open Markprompt',

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -15,9 +15,8 @@ type State = {
   isSearchEnabled: boolean;
   prompt: string;
   references: FileSectionReference[];
-  searchResults: SearchResultComponentProps[];
   searchQuery: string;
-  searchResults: SearchResultWithMetadata[];
+  searchResults: SearchResultComponentProps[];
   state: LoadingState;
 };
 

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -7,46 +7,47 @@ import {
 } from 'react';
 
 import type { SearchResultComponentProps } from './types.js';
-import { type LoadingState } from './useMarkprompt.js';
+import { type LoadingState, type Views } from './useMarkprompt.js';
 
 type State = {
-  activeSearchResult: string | undefined;
+  activeView: Views;
   answer: string | undefined;
   isSearchEnabled: boolean;
-  isSearchActive: boolean;
   prompt: string;
   references: FileSectionReference[];
   searchResults: SearchResultComponentProps[];
+  searchQuery: string;
+  searchResults: SearchResultWithMetadata[];
   state: LoadingState;
 };
 
 type Actions = {
   abort: () => void;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  setSearchQuery: Dispatch<SetStateAction<string>>;
   submitFeedback: (helpful: boolean) => void;
   submitPrompt: () => void;
   submitSearchQuery: (searchQuery: string) => void;
-  updateActiveSearchResult: Dispatch<SetStateAction<string | undefined>>;
-  updatePrompt: (nextPrompt: string) => void;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = (): void => {};
 
 const MarkpromptContext = createContext<State & Actions>({
-  activeSearchResult: undefined,
+  activeView: 'prompt',
   answer: undefined,
   isSearchEnabled: false,
-  isSearchActive: false,
   prompt: '',
   references: [],
+  searchQuery: '',
   searchResults: [],
   state: 'indeterminate',
   abort: noop,
+  setPrompt: noop,
+  setSearchQuery: noop,
   submitFeedback: noop,
   submitPrompt: noop,
   submitSearchQuery: noop,
-  updateActiveSearchResult: noop,
-  updatePrompt: noop,
 });
 
 function useMarkpromptContext(): State & Actions {

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -22,6 +22,7 @@ type State = {
 
 type Actions = {
   abort: () => void;
+  setActiveView: Dispatch<SetStateAction<Views>>;
   setPrompt: Dispatch<SetStateAction<string>>;
   setSearchQuery: Dispatch<SetStateAction<string>>;
   submitFeedback: (helpful: boolean) => void;
@@ -42,6 +43,7 @@ const MarkpromptContext = createContext<State & Actions>({
   searchResults: [],
   state: 'indeterminate',
   abort: noop,
+  setActiveView: noop,
   setPrompt: noop,
   setSearchQuery: noop,
   submitFeedback: noop,

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -480,7 +480,9 @@ type SearchResultsProps = PolymorphicComponentPropWithRef<
   'ul',
   {
     label?: string;
-    SearchResultComponent?: ElementType<SearchResultComponentProps>;
+    SearchResultComponent?: ElementType<
+      SearchResultComponentProps & { index?: number }
+    >;
   }
 >;
 
@@ -526,7 +528,6 @@ type SearchResultProps = PolymorphicComponentPropWithRef<
   'li',
   SearchResultComponentProps & {
     getHref?: (reference: FileSectionReference) => string;
-    index: number;
     onMouseOver?: () => void;
   }
 >;

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -495,47 +495,28 @@ const SearchResults = forwardRef<HTMLUListElement, SearchResultsProps>(
 
     const { searchResults } = useMarkpromptContext();
 
-    useEffect(() => {
-      if (!activeSearchResult) {
-        return;
-      }
-
-      const element = document.getElementById(activeSearchResult);
-      if (!element) {
-        return;
-      }
-
-      element.focus();
-      element.scrollIntoView({
-        block: 'nearest',
-      });
-    }, [activeSearchResult, searchResults]);
-
     return (
-      <>
-        <Component
-          {...rest}
-          ref={ref}
-          role="listbox"
-          id="markprompt-search-results"
-          tabIndex={0}
-          aria-label={label}
-        >
-          {searchResults.map((result, index) => {
-            const id = `markprompt-result-${index}`;
-            return (
-              <SearchResultComponent
-                role="option"
-                id={id}
-                onMouseOver={() => updateActiveSearchResult(id)}
-                aria-selected={id === activeSearchResult}
-                key={`${result.path}:${result.title}`}
-                {...result}
-              />
-            );
-          })}
-        </Component>
-      </>
+      <Component
+        {...rest}
+        ref={ref}
+        role="listbox"
+        id="markprompt-search-results"
+        tabIndex={0}
+        aria-label={label}
+      >
+        {searchResults.map((result, index) => {
+          const id = `markprompt-result-${index}`;
+          return (
+            <SearchResultComponent
+              role="option"
+              index={index}
+              id={id}
+              key={`${result.path}:${result.title}`}
+              {...result}
+            />
+          );
+        })}
+      </Component>
     );
   },
 );
@@ -545,9 +526,11 @@ type SearchResultProps = PolymorphicComponentPropWithRef<
   'li',
   SearchResultComponentProps & {
     getHref?: (reference: FileSectionReference) => string;
+    index: number;
     onMouseOver?: () => void;
   }
 >;
+
 const SearchResult = forwardRef<HTMLLIElement, SearchResultProps>(
   (props, ref) => {
     const {

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -1,4 +1,4 @@
-import type { FileSectionReference, Source } from '@markprompt/core';
+import type { FileSectionReference } from '@markprompt/core';
 import * as Dialog from '@radix-ui/react-dialog';
 import debounce from 'p-debounce';
 import React, {
@@ -25,10 +25,9 @@ import { ConditionalVisuallyHidden } from '../ConditionalWrap.js';
 import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants.js';
 import { MarkpromptContext, useMarkpromptContext } from '../context.js';
 import type {
-  SearchResultComponentProps,
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
-  SectionHeading,
+  SearchResultComponentProps,
 } from '../types.js';
 import { useMarkprompt, type UseMarkpromptOptions } from '../useMarkprompt.js';
 
@@ -556,11 +555,11 @@ export {
   AutoScroller,
   Close,
   Content,
-  PlainContent,
   Description,
   DialogTrigger,
   Form,
   Overlay,
+  PlainContent,
   Portal,
   Prompt,
   ForwardedReferences as References,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -115,24 +115,20 @@ type MarkpromptOptions = {
     cta?: string;
   };
   references?: {
-    /** Loading text, default: `Fetching relevant pages…` */
-    loadingText?: string;
-    /**
-     * Heading above the references
-     * @default "Answer generated from the following sources:"
-     **/
-    heading?: string;
     /** Callback to transform a reference into an href */
     getHref?: (reference: FileSectionReference) => string;
     /** Callback to transform a reference into a label */
     getLabel?: (reference: FileSectionReference) => string;
     /**
-     * [DEPRECATED] References title
+     * Heading above the references
      * @default "Answer generated from the following sources:"
      **/
-    referencesText?: string;
+    heading?: string;
+    /** Loading text, default: `Fetching relevant pages…` */
+    loadingText?: string;
     /**
-     * [DEPRECATED] Callback to transform a reference id into an href and text
+     * Callback to transform a reference id into an href and text
+     * @deprecated Use `getHref` and `getLabel` instead
      **/
     transformReferenceId?: (referenceId: string) => {
       href: string;
@@ -144,17 +140,17 @@ type MarkpromptOptions = {
    */
   search?: SubmitSearchQueryOptions & {
     /**
+     * When search is enabled, this label is used for the call-to-action button
+     * that switches to the search view that is shown in the prompt view.
+     */
+    cta?: string;
+    /**
      * Enable search
      * @default false
      **/
     enabled?: boolean;
     /** Callback to transform a search result into an href */
     getHref?: (reference: FileSectionReference) => string;
-    /**
-     * When search is enabled, this label is used for the call-to-action button
-     * that switches to the search view that is shown in the prompt view.
-     */
-    cta?: string;
     /**
      * Label for the search input, not shown but used for `aria-label`
      * @default "Search docs…"

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -108,8 +108,8 @@ type MarkpromptOptions = {
      **/
     placeholder?: string;
     /**
-     * When search is enabled, this label is used for the CTA button
-     * that opens the prompt.
+     * When search is enabled, this label is used for the call-to-action button
+     * that switches to the prompt view that is shown in the search view.
      * @default "Ask Docs AI…"
      **/
     cta?: string;
@@ -150,6 +150,21 @@ type MarkpromptOptions = {
     enabled?: boolean;
     /** Callback to transform a search result into an href */
     getHref?: (reference: FileSectionReference) => string;
+    /**
+     * When search is enabled, this label is used for the call-to-action button
+     * that switches to the search view that is shown in the prompt view.
+     */
+    cta?: string;
+    /**
+     * Label for the search input, not shown but used for `aria-label`
+     * @default "Search docs…"
+     **/
+    label?: string;
+    /**
+     * Placeholder for the search input
+     * @default "Search docs…"
+     */
+    placeholder?: string;
   };
   trigger?: {
     /**

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -42,11 +42,11 @@ export type SectionHeading = {
 };
 
 export type SearchResultComponentProps = {
+  isSection?: boolean;
   path: string;
+  reference: FileSectionReference;
   tag?: string;
   title: string;
-  isSection?: boolean;
-  reference: FileSectionReference;
 };
 
 type MarkpromptOptions = {

--- a/packages/react/src/useMarkprompt.test.ts
+++ b/packages/react/src/useMarkprompt.test.ts
@@ -50,19 +50,20 @@ describe('useMarkprompt', () => {
 
     expect(result.current).toStrictEqual({
       abort: expect.any(Function),
-      activeSearchResult: undefined,
+      activeView: 'prompt',
       answer: '',
-      isSearchActive: false,
       isSearchEnabled: false,
       prompt: '',
       references: [],
+      searchQuery: '',
       searchResults: [],
       state: 'indeterminate',
+      setActiveView: expect.any(Function),
+      setPrompt: expect.any(Function),
+      setSearchQuery: expect.any(Function),
       submitFeedback: expect.any(Function),
       submitPrompt: expect.any(Function),
       submitSearchQuery: expect.any(Function),
-      updateActiveSearchResult: expect.any(Function),
-      updatePrompt: expect.any(Function),
     });
   });
 
@@ -72,7 +73,7 @@ describe('useMarkprompt', () => {
     );
 
     act(() => {
-      result.current.updatePrompt('How much is 1+2?');
+      result.current.setPrompt('How much is 1+2?');
     });
 
     response = [

--- a/packages/react/src/useMarkprompt.tsx
+++ b/packages/react/src/useMarkprompt.tsx
@@ -28,8 +28,6 @@ export type LoadingState =
 export type Views = 'prompt' | 'search';
 
 export interface UseMarkpromptOptions {
-  /** The currently active view */
-  activeView: Views;
   /** Project key, required */
   projectKey: string;
   /** Project key, required */
@@ -63,6 +61,8 @@ export interface UseMarkpromptResult {
   state: LoadingState;
   /** Abort a pending request */
   abort: () => void;
+  /** Switch the active view between search and prompt */
+  setActiveView: Dispatch<SetStateAction<Views>>;
   /** Set a new value for the prompt */
   setPrompt: Dispatch<SetStateAction<string>>;
   /** Set a new value for the search query */
@@ -75,163 +75,11 @@ export interface UseMarkpromptResult {
   submitSearchQuery: (query: string) => void;
 }
 
-const mockData: SearchResultComponentProps[] = [
-  {
-    isSection: true,
-    path: '/getting-started',
-    reference: {
-      file: {
-        title: 'Getting Started',
-        path: '/path/to/getting-started.md',
-        source: {
-          type: 'github',
-        },
-      },
-      meta: {
-        leadHeading: {
-          id: 'introduction',
-          depth: 1,
-          value: 'Introduction',
-          slug: 'introduction',
-        },
-      },
-    },
-    tag: 'getting-started',
-    title: 'Getting Started',
-  },
-  {
-    isSection: false,
-    path: '/api-reference',
-    reference: {
-      file: {
-        title: 'API Reference',
-        path: '/path/to/api-reference.md',
-        source: {
-          type: 'github',
-        },
-      },
-    },
-    title: 'API Reference',
-  },
-  {
-    isSection: true,
-    path: '/guides',
-    reference: {
-      file: {
-        title: 'Guides',
-        path: '/path/to/guides.md',
-        source: {
-          type: 'github',
-        },
-      },
-      meta: {
-        leadHeading: {
-          id: 'getting-started',
-          depth: 1,
-          value: 'Getting Started',
-          slug: 'getting-started',
-        },
-      },
-    },
-    tag: 'guides',
-    title: 'Guides',
-  },
-  {
-    isSection: false,
-    path: '/examples',
-    reference: {
-      file: {
-        title: 'Examples',
-        path: '/path/to/examples.md',
-        source: {
-          type: 'github',
-        },
-      },
-    },
-    title: 'Examples',
-  },
-  {
-    isSection: true,
-    path: '/tutorials',
-    reference: {
-      file: {
-        title: 'Tutorials',
-        path: '/path/to/tutorials.md',
-        source: {
-          type: 'github',
-        },
-      },
-      meta: {
-        leadHeading: {
-          id: 'getting-started',
-          depth: 1,
-          value: 'Getting Started',
-          slug: 'getting-started',
-        },
-      },
-    },
-    tag: 'tutorials',
-    title: 'Tutorials',
-  },
-  {
-    isSection: false,
-    path: '/faq',
-    reference: {
-      file: {
-        title: 'FAQ',
-        path: '/path/to/faq.md',
-        source: {
-          type: 'github',
-        },
-      },
-    },
-    title: 'FAQ',
-  },
-  {
-    isSection: true,
-    path: '/blog',
-    reference: {
-      file: {
-        title: 'Blog',
-        path: '/path/to/blog.md',
-        source: {
-          type: 'github',
-        },
-      },
-      meta: {
-        leadHeading: {
-          id: 'latest-posts',
-          depth: 1,
-          value: 'Latest Posts',
-          slug: 'latest-posts',
-        },
-      },
-    },
-    tag: 'blog',
-    title: 'Blog',
-  },
-  {
-    isSection: false,
-    path: '/contact',
-    reference: {
-      file: {
-        title: 'Contact Us',
-        path: '/path/to/contact.md',
-        source: {
-          type: 'github',
-        },
-      },
-    },
-    title: 'Contact Us',
-  },
-];
-
 /**
  * A React hook with all the functionality you need to create an interactive
  * stateful Markprompt prompt with search and a prompt.
  */
 export function useMarkprompt({
-  activeView,
   projectKey,
   searchOptions,
   promptOptions,
@@ -243,9 +91,14 @@ export function useMarkprompt({
     );
   }
 
+  const [activeView, setActiveView] = useState<Views>(
+    searchOptions?.enabled ? 'search' : 'prompt',
+  );
+
   const [state, setState] = useState<LoadingState>('indeterminate');
-  const [searchResults, setSearchResults] =
-    useState<SearchResultComponentProps[]>(mockData);
+  const [searchResults, setSearchResults] = useState<
+    SearchResultComponentProps[]
+  >([]);
   const [answer, setAnswer] = useState('');
   const [references, setReferences] = useState<FileSectionReference[]>([]);
   const [prompt, setPrompt] = useState<string>('');
@@ -442,6 +295,7 @@ export function useMarkprompt({
       searchResults,
       state,
       abort,
+      setActiveView,
       setPrompt,
       setSearchQuery,
       submitFeedback,

--- a/packages/react/src/useMarkprompt.tsx
+++ b/packages/react/src/useMarkprompt.tsx
@@ -75,6 +75,157 @@ export interface UseMarkpromptResult {
   submitSearchQuery: (query: string) => void;
 }
 
+const mockData: SearchResultComponentProps[] = [
+  {
+    isSection: true,
+    path: '/getting-started',
+    reference: {
+      file: {
+        title: 'Getting Started',
+        path: '/path/to/getting-started.md',
+        source: {
+          type: 'github',
+        },
+      },
+      meta: {
+        leadHeading: {
+          id: 'introduction',
+          depth: 1,
+          value: 'Introduction',
+          slug: 'introduction',
+        },
+      },
+    },
+    tag: 'getting-started',
+    title: 'Getting Started',
+  },
+  {
+    isSection: false,
+    path: '/api-reference',
+    reference: {
+      file: {
+        title: 'API Reference',
+        path: '/path/to/api-reference.md',
+        source: {
+          type: 'github',
+        },
+      },
+    },
+    title: 'API Reference',
+  },
+  {
+    isSection: true,
+    path: '/guides',
+    reference: {
+      file: {
+        title: 'Guides',
+        path: '/path/to/guides.md',
+        source: {
+          type: 'github',
+        },
+      },
+      meta: {
+        leadHeading: {
+          id: 'getting-started',
+          depth: 1,
+          value: 'Getting Started',
+          slug: 'getting-started',
+        },
+      },
+    },
+    tag: 'guides',
+    title: 'Guides',
+  },
+  {
+    isSection: false,
+    path: '/examples',
+    reference: {
+      file: {
+        title: 'Examples',
+        path: '/path/to/examples.md',
+        source: {
+          type: 'github',
+        },
+      },
+    },
+    title: 'Examples',
+  },
+  {
+    isSection: true,
+    path: '/tutorials',
+    reference: {
+      file: {
+        title: 'Tutorials',
+        path: '/path/to/tutorials.md',
+        source: {
+          type: 'github',
+        },
+      },
+      meta: {
+        leadHeading: {
+          id: 'getting-started',
+          depth: 1,
+          value: 'Getting Started',
+          slug: 'getting-started',
+        },
+      },
+    },
+    tag: 'tutorials',
+    title: 'Tutorials',
+  },
+  {
+    isSection: false,
+    path: '/faq',
+    reference: {
+      file: {
+        title: 'FAQ',
+        path: '/path/to/faq.md',
+        source: {
+          type: 'github',
+        },
+      },
+    },
+    title: 'FAQ',
+  },
+  {
+    isSection: true,
+    path: '/blog',
+    reference: {
+      file: {
+        title: 'Blog',
+        path: '/path/to/blog.md',
+        source: {
+          type: 'github',
+        },
+      },
+      meta: {
+        leadHeading: {
+          id: 'latest-posts',
+          depth: 1,
+          value: 'Latest Posts',
+          slug: 'latest-posts',
+        },
+      },
+    },
+    tag: 'blog',
+    title: 'Blog',
+  },
+  {
+    isSection: false,
+    path: '/contact',
+    reference: {
+      file: {
+        title: 'Contact Us',
+        path: '/path/to/contact.md',
+        source: {
+          type: 'github',
+        },
+      },
+    },
+    title: 'Contact Us',
+  },
+];
+
 /**
  * A React hook with all the functionality you need to create an interactive
  * stateful Markprompt prompt with search and a prompt.
@@ -93,9 +244,8 @@ export function useMarkprompt({
   }
 
   const [state, setState] = useState<LoadingState>('indeterminate');
-  const [searchResults, setSearchResults] = useState<
-    SearchResultComponentProps[]
-  >([]);
+  const [searchResults, setSearchResults] =
+    useState<SearchResultComponentProps[]>(mockData);
   const [answer, setAnswer] = useState('');
   const [references, setReferences] = useState<FileSectionReference[]>([]);
   const [prompt, setPrompt] = useState<string>('');

--- a/packages/react/src/useMarkprompt.tsx
+++ b/packages/react/src/useMarkprompt.tsx
@@ -25,13 +25,15 @@ export type LoadingState =
   | 'streaming-answer'
   | 'done';
 
+export type Views = 'prompt' | 'search';
+
 export interface UseMarkpromptOptions {
+  /** The currently active view */
+  activeView: Views;
   /** Project key, required */
   projectKey: string;
   /** Project key, required */
   display?: MarkpromptOptions['display'];
-  /** Is search currently active */
-  isSearchActive?: boolean;
   /** Enable and configure prompt functionality */
   promptOptions?: Omit<SubmitPromptOptions, 'signal'>;
   /** Enable and configure search functionality */
@@ -43,28 +45,28 @@ export interface UseMarkpromptOptions {
 }
 
 export interface UseMarkpromptResult {
-  /** The currently active search result */
-  activeSearchResult: string | undefined;
-  /** The latest answer */
+  /** The currently active view */
+  activeView: Views;
+  /** The most recent answer */
   answer: string;
   /** Enable search functionality */
   isSearchEnabled: boolean;
-  /** Is search currently active */
-  isSearchActive: boolean;
   /** The current prompt */
   prompt: string;
   /** The references that belong to the latest answer */
   references: FileSectionReference[];
   /** Search results */
   searchResults: SearchResultComponentProps[];
-  /** The current loading state */
+  /** The current search query */
+  searchQuery: string;
+  /** The current state of request(s) */
   state: LoadingState;
   /** Abort a pending request */
   abort: () => void;
-  /** Update the currently active search result */
-  updateActiveSearchResult: Dispatch<SetStateAction<string | undefined>>;
   /** Set a new value for the prompt */
-  updatePrompt: Dispatch<SetStateAction<string>>;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  /** Set a new value for the search query */
+  setSearchQuery: Dispatch<SetStateAction<string>>;
   /** Submit user feedback */
   submitFeedback: (helpful: boolean) => Promise<void>;
   /** Submit the prompt */
@@ -78,8 +80,8 @@ export interface UseMarkpromptResult {
  * stateful Markprompt prompt with search and a prompt.
  */
 export function useMarkprompt({
+  activeView,
   projectKey,
-  isSearchActive,
   searchOptions,
   promptOptions,
   debug,
@@ -94,13 +96,11 @@ export function useMarkprompt({
   const [searchResults, setSearchResults] = useState<
     SearchResultComponentProps[]
   >([]);
-  const [activeSearchResult, setActiveSearchResult] = useState<
-    string | undefined
-  >();
   const [answer, setAnswer] = useState('');
   const [references, setReferences] = useState<FileSectionReference[]>([]);
   const [prompt, setPrompt] = useState<string>('');
   const [promptId, setPromptId] = useState<string>();
+  const [searchQuery, setSearchQuery] = useState<string>('');
 
   const controllerRef = useRef<AbortController>();
 
@@ -224,7 +224,6 @@ export function useMarkprompt({
       if (searchQuery === '') {
         if (controllerRef.current) controllerRef.current.abort();
         setSearchResults([]);
-        setActiveSearchResult(undefined);
         setState('indeterminate');
         return;
       }
@@ -251,8 +250,8 @@ export function useMarkprompt({
         setSearchResults(
           flattenSearchResults(searchQuery, searchResults.data) ?? [],
         );
+
         // initially focus the first result
-        setActiveSearchResult(`markprompt-result-0`);
         setState('done');
       });
 
@@ -285,27 +284,27 @@ export function useMarkprompt({
   return useMemo(
     () => ({
       answer,
-      activeSearchResult,
       isSearchEnabled: !!searchOptions?.enabled,
-      isSearchActive: !!isSearchActive,
+      activeView,
       prompt,
       references,
+      searchQuery,
       searchResults,
       state,
       abort,
-      updateActiveSearchResult: setActiveSearchResult,
-      updatePrompt: setPrompt,
+      setPrompt,
+      setSearchQuery,
       submitFeedback,
       submitPrompt,
       submitSearchQuery,
     }),
     [
+      activeView,
       answer,
-      activeSearchResult,
-      searchOptions?.enabled,
-      isSearchActive,
       prompt,
       references,
+      searchOptions?.enabled,
+      searchQuery,
       searchResults,
       state,
       abort,

--- a/packages/react/src/useMarkprompt.tsx
+++ b/packages/react/src/useMarkprompt.tsx
@@ -28,18 +28,18 @@ export type LoadingState =
 export type Views = 'prompt' | 'search';
 
 export interface UseMarkpromptOptions {
+  /** Render in a dialog or plain? */
+  display?: MarkpromptOptions['display'];
+  /** Display debug info */
+  debug?: boolean;
   /** Project key, required */
   projectKey: string;
-  /** Project key, required */
-  display?: MarkpromptOptions['display'];
   /** Enable and configure prompt functionality */
   promptOptions?: Omit<SubmitPromptOptions, 'signal'>;
   /** Enable and configure search functionality */
   searchOptions?: Omit<SubmitSearchQueryOptions, 'signal'> & {
     enabled?: boolean;
   };
-  /** Display debug info */
-  debug?: boolean;
 }
 
 export interface UseMarkpromptResult {


### PR DESCRIPTION
- searching and prompting are different activities that require different kinds of inputs
- this PR refactors the prompt and search view so they don't share an input but each have their own
- this change also allows us to simplify some of the view changing code in Markprompt
- then, it moves the focus management for search results out of our headless components and up an abstraction level into the newly added `SearchView` so that headless components do not include behavior that is too opinionated

I think we can go further here and also split up `useMarkprompt` and `MarkpromptContext` into separate hooks for search and prompt, to simplify hooks, context and their respective types, but that can be done at a later point.