### PR TITLE
Set state to cancelled when restoring pending/streaming messages

### DIFF
--- a/.changeset/thick-squids-yell.md
+++ b/.changeset/thick-squids-yell.md
@@ -1,0 +1,5 @@
+---
+'@markprompt/react': patch
+---
+
+Set state to cancelled when restoring pending/streaming messages

--- a/packages/react/src/chat/store.tsx
+++ b/packages/react/src/chat/store.tsx
@@ -362,7 +362,16 @@ export const createChatStore = ({
             const [conversationId, { messages }] = projectConversations[0];
 
             state.setConversationId(conversationId);
-            state.setMessages(messages);
+            state.setMessages(
+              messages.map((x) => ({
+                ...x,
+                state:
+                  // cancel any pending or streaming requests
+                  x.state === 'preload' || x.state === 'streaming-answer'
+                    ? 'cancelled'
+                    : x.state,
+              })),
+            );
           },
         },
       ),


### PR DESCRIPTION
Fixes #201 