### PR TITLE
Add error messages for chat and prompt view

### DIFF
--- a/.changeset/cool-parrots-worry.md
+++ b/.changeset/cool-parrots-worry.md
@@ -1,0 +1,7 @@
+---
+'@markprompt/react': minor
+'@markprompt/core': minor
+'@markprompt/css': minor
+---
+
+Show configurable error messages to users when upstream outages occur

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -27,6 +27,5 @@ if (el && el instanceof HTMLElement) {
     trigger: {
       buttonLabel: 'Ask AI',
     },
-    open: true,
   } satisfies MarkpromptOptions);
 }

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -27,5 +27,6 @@ if (el && el instanceof HTMLElement) {
     trigger: {
       buttonLabel: 'Ask AI',
     },
+    open: true,
   } satisfies MarkpromptOptions);
 }

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -25,6 +25,11 @@ export interface SubmitChatOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   conversationMetadata?: any;
   /**
+   * Enabled debug mode. This will log debug and error information to the console.
+   * @default false
+   */
+  debug?: boolean;
+  /**
    * Message returned when the model does not have an answer
    * @default "Sorry, I am not sure how to answer that."
    **/
@@ -172,6 +177,13 @@ export async function submitChat(
       return;
     }
 
+    if (debug) {
+      const res2 = res.clone();
+      const { debugInfo } = await res2.json();
+      // eslint-disable-next-line no-console
+      if (debugInfo) console.debug(debugInfo);
+    }
+
     const data = parseEncodedJSONHeader(res, 'x-markprompt-data');
 
     if (typeof data === 'object' && data !== null) {
@@ -184,13 +196,6 @@ export async function submitChat(
       if ('promptId' in data && typeof data.promptId === 'string') {
         onPromptId(data?.promptId);
       }
-    }
-
-    if (debug) {
-      const res2 = res.clone();
-      const { debugInfo } = await res2.json();
-      // eslint-disable-next-line no-console
-      console.debug(debugInfo);
     }
 
     const reader = res.body.getReader();

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -1702,7 +1702,6 @@
   padding-inline: 1.5rem;
   padding-block: 0.75rem;
   font-size: var(--markprompt-text-size);
-  color: var(--markprompt-foreground);
   background: var(--markprompt-error-background);
   border-top: var(--markprompt-error-foreground);
   color: var(--markprompt-error-foreground);

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -22,6 +22,8 @@
   --markprompt-shadow: 0 1px 2px 0 #0000000d;
   --markprompt-ring-shadow: 0 0 #0000;
   --markprompt-ring-offset-shadow: 0 0 #0000;
+  --markprompt-error-background: #fef2f2;
+  --markprompt-error-foreground: #991b1b;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -42,6 +44,8 @@
     --markprompt-secondaryHighlight: #a855f7;
     --markprompt-overlay: #00000040;
     --markprompt-ring: #fff;
+    --markprompt-error-background: #450a0a;
+    --markprompt-error-foreground: #fecaca;
   }
 }
 
@@ -385,17 +389,30 @@
 :where(.MarkpromptForm) {
   display: flex;
   flex: 1 1 auto;
-  align-items: center;
-  border-bottom: 1px solid var(--markprompt-border);
-  padding: 0 1rem 0 0.75rem;
-  gap: 0.75rem;
+  flex-direction: column;
 }
 
 :where(.MarkpromptChatView .MarkpromptForm) {
   position: relative;
-  border-top: 1px solid var(--markprompt-border);
-  border-bottom: 0;
   background-color: var(--markprompt-background);
+  flex-direction: column-reverse;
+  align-items: stretch;
+}
+
+:where(.MarkpromptPromptWrapper) {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0 0.75rem;
+}
+
+:where(.MarkpromptChatView .MarkpromptPromptWrapper) {
+  border-top: 1px solid var(--markprompt-border);
+}
+
+:where(.MarkpromptPromptView .MarkpromptPromptWrapper),
+:where(.MarkpromptSearchView .MarkpromptPromptWrapper) {
+  border-bottom: 1px solid var(--markprompt-border);
 }
 
 :where(.MarkpromptMessageAnswerContainer) {
@@ -1555,10 +1572,9 @@
 :where(.MarkpromptChatActions) {
   display: flex;
   gap: 0.25rem;
-  position: absolute;
-  top: -1rem;
-  right: 1.25rem;
-  transform: translateY(-100%);
+  margin-bottom: 0.75rem;
+  margin-right: 0.75rem;
+  align-self: flex-end;
 }
 
 :where(.MarkpromptNewChatIcon) {
@@ -1680,6 +1696,22 @@
 
 :where(.MarkpromptDefaultViewMessagePromptsContainer a:hover) {
   opacity: 0.8;
+}
+
+:where(.MarkpromptErrorMessage) {
+  padding-inline: 1.5rem;
+  padding-block: 0.75rem;
+  font-size: var(--markprompt-text-size);
+  color: var(--markprompt-foreground);
+  background: var(--markprompt-error-background);
+  border-top: var(--markprompt-error-foreground);
+  color: var(--markprompt-error-foreground);
+}
+
+:where(.MarkpromptErrorMessage p) {
+  margin: 0;
+  font-weight: 500;
+  text-wrap: pretty;
 }
 
 @keyframes markprompt-show-content {

--- a/packages/react/src/chat/ChatViewForm.tsx
+++ b/packages/react/src/chat/ChatViewForm.tsx
@@ -23,7 +23,7 @@ import type { View } from '../useViews.js';
 
 interface ChatViewFormProps {
   activeView?: View;
-  chatOptions: MarkpromptOptions['chat'];
+  chatOptions: NonNullable<MarkpromptOptions['chat']>;
 }
 
 export function ChatViewForm(props: ChatViewFormProps): ReactElement {
@@ -39,6 +39,7 @@ export function ChatViewForm(props: ChatViewFormProps): ReactElement {
     (state) => state.regenerateLastAnswer,
   );
   const conversations = useChatStore(selectProjectConversations);
+  const error = useChatStore((state) => state.error);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
@@ -88,22 +89,30 @@ export function ChatViewForm(props: ChatViewFormProps): ReactElement {
 
   return (
     <BaseMarkprompt.Form className={'MarkpromptForm'} onSubmit={handleSubmit}>
-      <BaseMarkprompt.Prompt
-        ref={inputRef}
-        className="MarkpromptPrompt"
-        name="markprompt-prompt"
-        type="text"
-        autoFocus
-        placeholder={chatOptions?.placeholder}
-        labelClassName="MarkpromptPromptLabel"
-        value={prompt}
-        onChange={(event) => setPrompt(event.target.value)}
-        label={
-          <AccessibleIcon.Root label={chatOptions!.label!}>
-            <SparklesIcon className="MarkpromptSearchIcon" />
-          </AccessibleIcon.Root>
-        }
-      />
+      <div className="MarkpromptPromptWrapper">
+        <BaseMarkprompt.Prompt
+          ref={inputRef}
+          className="MarkpromptPrompt"
+          name="markprompt-prompt"
+          type="text"
+          autoFocus
+          placeholder={chatOptions?.placeholder}
+          labelClassName="MarkpromptPromptLabel"
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          label={
+            <AccessibleIcon.Root label={chatOptions!.label!}>
+              <SparklesIcon className="MarkpromptSearchIcon" />
+            </AccessibleIcon.Root>
+          }
+        />
+      </div>
+
+      {error && (
+        <BaseMarkprompt.ErrorMessage className="MarkpromptErrorMessage">
+          {chatOptions.errorText}
+        </BaseMarkprompt.ErrorMessage>
+      )}
 
       <div className="MarkpromptChatActions">
         {lastMessageState && lastMessageState !== 'indeterminate' && (

--- a/packages/react/src/chat/store.tsx
+++ b/packages/react/src/chat/store.tsx
@@ -57,6 +57,8 @@ export interface ChatStoreState {
   abort?: () => void;
   projectKey: string;
   conversationId?: string;
+  error?: string;
+  setError: (error?: string) => void;
   setConversationId: (conversationId: string) => void;
   selectConversation: (conversationId?: string) => void;
   messages: ChatViewMessage[];
@@ -113,6 +115,12 @@ export const createChatStore = ({
             [projectKey]: [],
           },
           messagesByConversationId: {},
+          error: undefined,
+          setError: (error?: string) => {
+            set((state) => {
+              state.error = error;
+            });
+          },
           setConversationId: (conversationId: string) => {
             set((state) => {
               // set the conversation id for this session
@@ -191,6 +199,8 @@ export const createChatStore = ({
           },
           submitChat: (prompt: string) => {
             const id = crypto.randomUUID();
+
+            get().setError(undefined);
 
             set((state) => {
               state.messages.push({
@@ -273,7 +283,7 @@ export const createChatStore = ({
                 if (isAbortError(error)) return;
 
                 // eslint-disable-next-line no-console
-                console.error(error);
+                get().setError(error.message);
               },
               {
                 conversationId: get().conversationId,

--- a/packages/react/src/constants.tsx
+++ b/packages/react/src/constants.tsx
@@ -194,11 +194,15 @@ export const DEFAULT_MARKPROMPT_OPTIONS = {
     tabLabel: 'Ask AI',
     placeholder: 'Ask AI…',
     history: true,
+    errorText:
+      'Sorry, it looks like the bot is having a hard time! Please try again in a few minutes.',
   },
   prompt: {
     label: 'Ask AI',
     tabLabel: 'Ask AI',
     placeholder: 'Ask AI…',
+    errorText:
+      'Sorry, it looks like the bot is having a hard time! Please try again in a few minutes.',
   },
   references: {
     loadingText: 'Fetching relevant pages…',

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -559,6 +559,21 @@ const SearchResult = forwardRef<HTMLLIElement, SearchResultProps>(
 );
 SearchResult.displayName = 'Markprompt.SearchResult';
 
+interface ErrorMessageProps {
+  className?: string;
+  children: ReactNode;
+}
+
+function ErrorMessage(props: ErrorMessageProps): ReactElement {
+  const { className, children } = props;
+  return (
+    <div className={className}>
+      <p>{children}</p>
+    </div>
+  );
+}
+ErrorMessage.displayName = 'Markprompt.ErrorMessage';
+
 export {
   Answer,
   AutoScroller,
@@ -566,6 +581,7 @@ export {
   Content,
   Description,
   DialogTrigger,
+  ErrorMessage,
   Form,
   Overlay,
   PlainContent,
@@ -582,6 +598,7 @@ export {
   type ContentProps,
   type DescriptionProps,
   type DialogTriggerProps,
+  type ErrorMessageProps,
   type FormProps,
   type OverlayProps,
   type PortalProps,

--- a/packages/react/src/prompt/PromptView.tsx
+++ b/packages/react/src/prompt/PromptView.tsx
@@ -55,6 +55,7 @@ export function PromptView(props: PromptViewProps): ReactElement {
   const {
     abort,
     answer,
+    error,
     submitPrompt,
     setPrompt,
     prompt,
@@ -100,29 +101,37 @@ export function PromptView(props: PromptViewProps): ReactElement {
   return (
     <div className="MarkpromptPromptView">
       <BaseMarkprompt.Form className="MarkpromptForm" onSubmit={handleSubmit}>
-        <BaseMarkprompt.Prompt
-          ref={inputRef}
-          className="MarkpromptPrompt"
-          name="markprompt-prompt"
-          onChange={handleChange}
-          value={prompt}
-          type="text"
-          placeholder={
-            promptOptions?.placeholder ??
-            DEFAULT_MARKPROMPT_OPTIONS.prompt!.placeholder!
-          }
-          labelClassName="MarkpromptPromptLabel"
-          label={
-            <AccessibleIcon.Root
-              label={
-                promptOptions?.label ??
-                DEFAULT_MARKPROMPT_OPTIONS.prompt!.label!
-              }
-            >
-              <SparklesIcon className="MarkpromptSearchIcon" />
-            </AccessibleIcon.Root>
-          }
-        />
+        <div className="MarkpromptPromptWrapper">
+          <BaseMarkprompt.Prompt
+            ref={inputRef}
+            className="MarkpromptPrompt"
+            name="markprompt-prompt"
+            onChange={handleChange}
+            value={prompt}
+            type="text"
+            placeholder={
+              promptOptions?.placeholder ??
+              DEFAULT_MARKPROMPT_OPTIONS.prompt!.placeholder!
+            }
+            labelClassName="MarkpromptPromptLabel"
+            label={
+              <AccessibleIcon.Root
+                label={
+                  promptOptions?.label ??
+                  DEFAULT_MARKPROMPT_OPTIONS.prompt!.label!
+                }
+              >
+                <SparklesIcon className="MarkpromptSearchIcon" />
+              </AccessibleIcon.Root>
+            }
+          />
+        </div>
+
+        {error && (
+          <BaseMarkprompt.ErrorMessage className="MarkpromptErrorMessage">
+            {promptOptions.errorText}
+          </BaseMarkprompt.ErrorMessage>
+        )}
       </BaseMarkprompt.Form>
 
       <AnswerContainer

--- a/packages/react/src/prompt/usePrompt.test.ts
+++ b/packages/react/src/prompt/usePrompt.test.ts
@@ -73,14 +73,15 @@ describe('usePrompt', () => {
 
     expect(result.current).toStrictEqual({
       abort: expect.any(Function),
-      answer: '',
-      prompt: '',
-      references: [],
-      promptId: undefined,
-      state: 'indeterminate',
-      setPrompt: expect.any(Function),
-      submitFeedback: expect.any(Function),
       abortFeedbackRequest: expect.any(Function),
+      answer: '',
+      error: undefined,
+      prompt: '',
+      promptId: undefined,
+      references: [],
+      setPrompt: expect.any(Function),
+      state: 'indeterminate',
+      submitFeedback: expect.any(Function),
       submitPrompt: expect.any(Function),
     } satisfies UsePromptResult);
   });

--- a/packages/react/src/prompt/usePrompt.ts
+++ b/packages/react/src/prompt/usePrompt.ts
@@ -32,6 +32,7 @@ export interface UsePromptOptions {
 
 export interface UsePromptResult {
   answer: string;
+  error?: string;
   prompt: string;
   promptId?: string;
   references: FileSectionReference[];
@@ -60,6 +61,7 @@ export function usePrompt({
   const [references, setReferences] = useState<FileSectionReference[]>([]);
   const [prompt, setPrompt] = useState<string>('');
   const [promptId, setPromptId] = useState<string>();
+  const [error, setError] = useState<string | undefined>();
 
   const { ref: controllerRef, abort } = useAbortController();
 
@@ -86,6 +88,7 @@ export function usePrompt({
       setReferences([]);
       setPromptId(undefined);
       setState('preload');
+      setError(undefined);
 
       const controller = new AbortController();
       controllerRef.current = controller;
@@ -106,10 +109,7 @@ export function usePrompt({
         (error) => {
           // ignore abort errors
           if (isAbortError(error)) return;
-
-          // todo: surface errors to the user
-          // eslint-disable-next-line no-console
-          console.error(error);
+          setError(error.message);
         },
         {
           ...promptOptions,
@@ -135,6 +135,7 @@ export function usePrompt({
   return useMemo(
     () => ({
       answer,
+      error,
       prompt,
       promptId,
       references,
@@ -147,6 +148,7 @@ export function usePrompt({
     }),
     [
       answer,
+      error,
       prompt,
       promptId,
       references,

--- a/packages/react/src/search/SearchView.tsx
+++ b/packages/react/src/search/SearchView.tsx
@@ -174,23 +174,25 @@ export function SearchView(props: SearchViewProps): ReactElement {
   return (
     <div className="MarkpromptSearchView">
       <BaseMarkprompt.Form className="MarkpromptForm" onSubmit={handleSubmit}>
-        <BaseMarkprompt.Prompt
-          ref={inputRef}
-          className="MarkpromptPrompt"
-          name={searchInputName}
-          placeholder={searchOptions?.placeholder}
-          labelClassName="MarkpromptPromptLabel"
-          value={searchQuery}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          aria-controls="markprompt-search-results"
-          aria-activedescendant={activeSearchResult?.id}
-          label={
-            <AccessibleIcon.Root label={searchOptions?.label}>
-              <SearchIcon className="MarkpromptSearchIcon" />
-            </AccessibleIcon.Root>
-          }
-        />
+        <div className="MarkpromptPromptWrapper">
+          <BaseMarkprompt.Prompt
+            ref={inputRef}
+            className="MarkpromptPrompt"
+            name={searchInputName}
+            placeholder={searchOptions?.placeholder}
+            labelClassName="MarkpromptPromptLabel"
+            value={searchQuery}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            aria-controls="markprompt-search-results"
+            aria-activedescendant={activeSearchResult?.id}
+            label={
+              <AccessibleIcon.Root label={searchOptions?.label}>
+                <SearchIcon className="MarkpromptSearchIcon" />
+              </AccessibleIcon.Root>
+            }
+          />
+        </div>
       </BaseMarkprompt.Form>
 
       <SearchResultsContainer

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -144,6 +144,11 @@ export interface MarkpromptOptions {
      **/
     placeholder?: string;
     /**
+     * Default error text
+     * @default "Sorry, it looks like the bot is having a hard time! Please try again in a few minutes."
+     */
+    errorText?: string;
+    /**
      * Show sender info, like avatar
      * @default true
      **/
@@ -184,6 +189,11 @@ export interface MarkpromptOptions {
      * Default (empty) view
      */
     defaultView?: DefaultViewProps;
+    /**
+     * Default error text
+     * @default "Sorry, it looks like the bot is having a hard time! Please try again in a few minutes."
+     */
+    errorText?: string;
   };
   references?: {
     /**


### PR DESCRIPTION
This PR adds configurable error messages for `PromptView` and `ChatView` that are shown to users when upstream outages occur.

The underlying cause can be logged to console by enabling `debug` in either chat or prompt options.