### PR TITLE
Use version header

### DIFF
--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -216,7 +216,10 @@ export async function submitChat(
 
     const res = await fetch(apiUrl, {
       method: 'POST',
-      headers: new Headers({ 'Content-Type': 'application/json' }),
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        'X-API-Version': '2023-12-01',
+      }),
       // Some properties may be non-serializable, like callback, so
       // make sure to safely stringify the payload.
       body: safeStringify({
@@ -280,11 +283,6 @@ export async function submitChat(
   }
 }
 export interface SubmitChatGeneratorOptions {
-  /**
-   * API version
-   * @default "2023-10-20"
-   */
-  version?: '2023-12-01';
   /**
    * URL at which to fetch completions
    * @default "https://api.markprompt.com/chat"
@@ -396,7 +394,6 @@ export interface SubmitChatGeneratorOptions {
 
 export const DEFAULT_SUBMIT_CHAT_GENERATOR_OPTIONS = {
   apiUrl: 'https://api.markprompt.com/chat',
-  version: '2023-12-01',
   frequencyPenalty: 0,
   iDontKnowMessage: 'Sorry, I am not sure how to answer that.',
   maxTokens: 500,
@@ -440,7 +437,6 @@ const validSubmitChatGeneratorOptionsKeys: (keyof SubmitChatGeneratorOptions)[] 
     'tool_choice',
     'tools',
     'topP',
-    'version',
   ];
 
 const isValidSubmitChatGeneratorOptionsKey = (
@@ -482,7 +478,10 @@ export async function* submitChatGenerator(
 
   const res = await fetch(apiUrl, {
     method: 'POST',
-    headers: new Headers({ 'Content-Type': 'application/json' }),
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      'X-API-Version': '2023-12-01',
+    }),
     body: JSON.stringify({ projectKey, messages, debug, ...resolvedOptions }),
     signal,
   });

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -49,6 +49,7 @@ export async function submitFeedback(
       method: 'POST',
       headers: new Headers({
         'Content-Type': 'application/json',
+        'X-API-Version': '2023-12-01',
       }),
       body: JSON.stringify(feedback),
       signal: resolvedOptions?.signal,

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -81,6 +81,9 @@ export async function submitSearchQuery(
     const res = await fetch(`${apiUrl}?${params.toString()}`, {
       method: 'GET',
       signal: options?.signal,
+      headers: new Headers({
+        'X-API-Version': '2023-12-01',
+      }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
Moved the version to the header, aligned with the changes on the Markprompt API. The reason to move the version to the header instead of the query parameter is that it simplifies the API. For instance, when using the `/train` endpoint, the user can upload binary data (such as a zip file), meaning the request needs to be of `application/zip` content type. Passing along the version as a query parameter would mean either passing it in the query string, or making the request a `multipart/form-data`, which is an unnecessary complexity. Passing it in the header makes it decorrelated from the content type and makes the API more consistent.