### PR TITLE
Fix for wrongly updated `module` and `moduleResolution`

### DIFF
--- a/.changeset/dry-items-refuse.md
+++ b/.changeset/dry-items-refuse.md
@@ -1,0 +1,8 @@
+---
+'@markprompt/docusaurus-theme-search': minor
+'@markprompt/react': minor
+'@markprompt/core': minor
+'@markprompt/web': minor
+---
+
+Use `module: nodenext` and `moduleResolution: nodenext` and update tsconfigs to modern standards

--- a/packages/core/src/chat.test.ts
+++ b/packages/core/src/chat.test.ts
@@ -19,8 +19,8 @@ import {
   SubmitChatOptions,
   SubmitChatReturn,
   SubmitChatYield,
-} from './index';
-import { formatEvent, getChunk } from '../../../test/utils';
+} from './index.js';
+import { formatEvent, getChunk } from '../../../test/utils.js';
 
 describe('submitChat', () => {
   const encoder = new TextEncoder();

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -1,6 +1,6 @@
 import defaults from 'defaults';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
-import mergeWith from 'lodash-es/mergeWith';
+import mergeWith from 'lodash-es/mergeWith.js';
 
 import type {
   Chat,
@@ -10,14 +10,14 @@ import type {
   ChatCompletionToolChoiceOption,
   ChatCompletionMetadata,
   OpenAIModelId,
-} from './types';
+} from './types.js';
 import {
   isChatCompletion,
   isChatCompletionChunk,
   isChatCompletionMessage,
   isMarkpromptMetadata,
   parseEncodedJSONHeader,
-} from './utils';
+} from './utils.js';
 
 export type {
   ChatCompletionMessageParam,
@@ -232,7 +232,11 @@ export async function* submitChat(
 
   if (res.headers.get('Content-Type')?.includes('application/json')) {
     const json = await res.json();
-    if (isChatCompletion(json) && isMarkpromptMetadata(data)) {
+    if (
+      isChatCompletion(json) &&
+      isMarkpromptMetadata(data) &&
+      json.choices[0]
+    ) {
       return { ...json.choices[0].message, ...data };
     } else {
       if (isMarkpromptMetadata(data)) {
@@ -300,7 +304,7 @@ export async function* submitChat(
       });
     }
 
-    mergeWith(completion, json.choices[0].delta, concatStrings);
+    mergeWith(completion, json.choices[0]?.delta, concatStrings);
 
     /**
      * If we do not yield a structuredClone here, the completion object will

--- a/packages/core/src/feedback.test.ts
+++ b/packages/core/src/feedback.test.ts
@@ -2,7 +2,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 
-import { DEFAULT_SUBMIT_FEEDBACK_OPTIONS, submitFeedback } from './index';
+import { DEFAULT_SUBMIT_FEEDBACK_OPTIONS, submitFeedback } from './index.js';
 
 let status = 200;
 

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -1,6 +1,6 @@
 import defaults from 'defaults';
 
-import type { PromptFeedback } from './types';
+import type { PromptFeedback } from './types.js';
 
 export interface SubmitFeedbackBody {
   /** Prompt feedback */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,14 +5,14 @@ export {
   type SubmitChatOptions,
   type SubmitChatReturn,
   type SubmitChatYield,
-} from './chat';
+} from './chat.js';
 
 export {
   DEFAULT_SUBMIT_FEEDBACK_OPTIONS,
   submitFeedback,
   type SubmitFeedbackBody,
   type SubmitFeedbackOptions,
-} from './feedback';
+} from './feedback.js';
 
 export {
   DEFAULT_SUBMIT_SEARCH_QUERY_OPTIONS,
@@ -20,7 +20,7 @@ export {
   submitSearchQuery,
   type SubmitSearchQueryOptions,
   type AlgoliaProvider,
-} from './search';
+} from './search.js';
 
 export {
   OPENAI_CHAT_COMPLETIONS_MODELS,
@@ -54,7 +54,7 @@ export {
   type SearchResultsResponse,
   type Source,
   type SourceType,
-} from './types';
+} from './types.js';
 
 export {
   getErrorMessage,
@@ -68,4 +68,4 @@ export {
   isToolCall,
   isToolCalls,
   parseEncodedJSONHeader,
-} from './utils';
+} from './utils.js';

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -17,8 +17,8 @@ import {
   submitSearchQuery,
   type AlgoliaDocSearchHit,
   type SearchResult,
-} from './index';
-import type { AlgoliaProvider } from './search';
+} from './index.js';
+import type { AlgoliaProvider } from './search.js';
 
 const searchResults: SearchResult[] = [
   {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -3,8 +3,8 @@ import type { SearchOptions } from '@algolia/client-search';
 import type {
   AlgoliaDocSearchResultsResponse,
   SearchResultsResponse,
-} from './types';
-import { getErrorMessage, isAbortError } from './utils';
+} from './types.js';
+import { getErrorMessage, isAbortError } from './utils.js';
 
 export interface SubmitSearchQueryOptions {
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import type { DocSearchHit } from './docsearch';
+import type { DocSearchHit } from './docsearch.js';
 
 export type {
   Chat,

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -12,7 +12,7 @@ import {
   isChatCompletionChunk,
   isKeyOf,
   isChatCompletionMessage,
-} from './utils';
+} from './utils.js';
 
 const encoder = new TextEncoder();
 const unencodedObject = { data: 'Some text' };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,7 +5,7 @@ import type {
   ChatCompletionMessageToolCall,
   ChatCompletionMetadata,
   FileSectionReference,
-} from './types';
+} from './types.js';
 
 export type {
   ChatCompletion,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,20 +1,27 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "esnext"],
-    "composite": true,
-    "rootDir": "src",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es2021",
+    // base
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+
+    // strictness
+    "strict": true,
+
+    // transpilation
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist/",
+    "rootDir": "src/",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "incremental": true,
-    "outDir": "dist/",
-    "strict": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
+    "composite": true,
+
+    // runtime
+    "lib": ["dom", "dom.iterable", "es2023"],
   },
   "include": ["src/*"],
   "exclude": ["src/*.test.ts"],

--- a/packages/docusaurus-theme-search/tsconfig.json
+++ b/packages/docusaurus-theme-search/tsconfig.json
@@ -2,20 +2,31 @@
   "include": ["src"],
   "references": [{ "path": "../react/tsconfig.build.json" }],
   "compilerOptions": {
-    "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "rootDir": "src",
-    "strict": true,
-    "jsx": "react-jsx",
-    "outDir": "dist",
+    // base
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es2022",
-    "lib": ["DOM", "ESNext"],
+    "moduleDetection": "force",
     "isolatedModules": true,
+
+    // strictness
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+
+    // transpilation
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "jsx": "react-jsx",
+
+    // runtime
+    "lib": ["dom", "dom.iterable", "es2023"],
+
     "types": ["@docusaurus/module-type-aliases"],
     "paths": {
       "@markprompt/core": ["../core/src"],

--- a/packages/docusaurus-theme-search/tsconfig.json
+++ b/packages/docusaurus-theme-search/tsconfig.json
@@ -23,6 +23,7 @@
     "declarationMap": true,
     "composite": true,
     "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
 
     // runtime
     "lib": ["dom", "dom.iterable", "es2023"],

--- a/packages/react/src/Markprompt.test.tsx
+++ b/packages/react/src/Markprompt.test.tsx
@@ -2,7 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { Markprompt, closeMarkprompt, openMarkprompt } from './index';
+import { Markprompt, closeMarkprompt, openMarkprompt } from './index.js';
 
 describe('Markprompt', () => {
   it('renders', async () => {

--- a/packages/react/src/Markprompt.tsx
+++ b/packages/react/src/Markprompt.tsx
@@ -4,17 +4,17 @@ import { clsx } from 'clsx';
 import Emittery from 'emittery';
 import { useEffect, useState, type ReactElement } from 'react';
 
-import { ChatView } from './chat/ChatView';
-import { DEFAULT_MARKPROMPT_OPTIONS } from './constants';
-import { ChatIcon, CloseIcon, SparklesIcon } from './icons';
-import { ChatProvider, useChatStore } from './index';
-import * as BaseMarkprompt from './primitives/headless';
-import { SearchBoxTrigger } from './search/SearchBoxTrigger';
-import { SearchView } from './search/SearchView';
-import { type MarkpromptOptions, type View } from './types';
-import { useDefaults } from './useDefaults';
-import { useMediaQuery } from './useMediaQuery';
-import { useViews } from './useViews';
+import { ChatView } from './chat/ChatView.js';
+import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
+import { ChatIcon, CloseIcon, SparklesIcon } from './icons.js';
+import { ChatProvider, useChatStore } from './index.js';
+import * as BaseMarkprompt from './primitives/headless.js';
+import { SearchBoxTrigger } from './search/SearchBoxTrigger.js';
+import { SearchView } from './search/SearchView.js';
+import { type MarkpromptOptions, type View } from './types.js';
+import { useDefaults } from './useDefaults.js';
+import { useMediaQuery } from './useMediaQuery.js';
+import { useViews } from './useViews.js';
 
 type MarkpromptProps = MarkpromptOptions &
   Omit<

--- a/packages/react/src/chat/Answer.tsx
+++ b/packages/react/src/chat/Answer.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import { type ReactElement } from 'react';
 
-import type { ChatLoadingState } from '../chat/store';
-import * as BaseMarkprompt from '../primitives/headless';
+import type { ChatLoadingState } from '../chat/store.js';
+import * as BaseMarkprompt from '../primitives/headless.js';
 
 interface CaretProps {
   answer: string;

--- a/packages/react/src/chat/AssistantMessage.tsx
+++ b/packages/react/src/chat/AssistantMessage.tsx
@@ -1,13 +1,13 @@
 import { isToolCalls } from '@markprompt/core';
 import { useMemo } from 'react';
 
-import { DefaultToolCallsConfirmation } from './DefaultToolCallsConfirmation';
-import { MessageAnswer } from './MessageAnswer';
-import { useChatStore, type ChatViewMessage } from './store';
-import { Feedback } from '../feedback/Feedback';
-import { useFeedback } from '../feedback/useFeedback';
-import { BotIcon } from '../icons';
-import type { MarkpromptOptions } from '../types';
+import { DefaultToolCallsConfirmation } from './DefaultToolCallsConfirmation.js';
+import { MessageAnswer } from './MessageAnswer.js';
+import { useChatStore, type ChatViewMessage } from './store.js';
+import { Feedback } from '../feedback/Feedback.js';
+import { useFeedback } from '../feedback/useFeedback.js';
+import { BotIcon } from '../icons.js';
+import type { MarkpromptOptions } from '../types.js';
 
 interface AssistantMessageProps {
   chatOptions: NonNullable<MarkpromptOptions['chat']>;

--- a/packages/react/src/chat/ChatView.test.tsx
+++ b/packages/react/src/chat/ChatView.test.tsx
@@ -17,14 +17,14 @@ import {
   vi,
 } from 'vitest';
 
-import { ChatView } from './ChatView';
+import { ChatView } from './ChatView.js';
 import {
   createChatStore,
   useChatStore,
   type ChatViewMessage,
   ChatProvider,
-} from './store';
-import type { MarkpromptOptions, View } from '../types';
+} from './store.js';
+import type { MarkpromptOptions, View } from '../types.js';
 
 const encoder = new TextEncoder();
 let markpromptData: {
@@ -1076,7 +1076,7 @@ export function encodeData(text: string): string {
   let output = '';
 
   for (let i = 0, l = lines.length; i < l; ++i) {
-    line = lines[i];
+    line = lines[i]!;
 
     output += `data: ${line}`;
     output += i + 1 === l ? '\n\n' : '\n';

--- a/packages/react/src/chat/ChatView.tsx
+++ b/packages/react/src/chat/ChatView.tsx
@@ -1,10 +1,10 @@
-import { ChatViewForm } from './ChatViewForm';
-import { ConversationSidebar } from './ConversationSidebar';
-import { Messages } from './Messages';
-import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants';
-import { ChevronLeftIcon } from '../icons';
-import type { MarkpromptOptions, View } from '../types';
-import { useDefaults } from '../useDefaults';
+import { ChatViewForm } from './ChatViewForm.js';
+import { ConversationSidebar } from './ConversationSidebar.js';
+import { Messages } from './Messages.js';
+import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants.js';
+import { ChevronLeftIcon } from '../icons.js';
+import type { MarkpromptOptions, View } from '../types.js';
+import { useDefaults } from '../useDefaults.js';
 
 export interface ChatViewProps {
   activeView?: View;

--- a/packages/react/src/chat/ChatViewForm.tsx
+++ b/packages/react/src/chat/ChatViewForm.tsx
@@ -9,11 +9,11 @@ import {
   useMemo,
 } from 'react';
 
-import { ConversationSelect } from './ConversationSelect';
-import { ChatContext, useChatStore } from './store';
-import { LoadingIcon, SendIcon, StopInsideLoadingIcon } from '../icons';
-import * as BaseMarkprompt from '../primitives/headless';
-import type { MarkpromptOptions, View } from '../types';
+import { ConversationSelect } from './ConversationSelect.js';
+import { ChatContext, useChatStore } from './store.js';
+import { LoadingIcon, SendIcon, StopInsideLoadingIcon } from '../icons.js';
+import * as BaseMarkprompt from '../primitives/headless.js';
+import type { MarkpromptOptions, View } from '../types.js';
 
 interface ChatViewFormProps {
   activeView?: View;

--- a/packages/react/src/chat/ConversationSelect.tsx
+++ b/packages/react/src/chat/ConversationSelect.tsx
@@ -1,6 +1,6 @@
-import { selectProjectConversations, useChatStore } from './store';
-import { CounterClockwiseClockIcon, PlusIcon } from '../icons';
-import { Select } from '../primitives/Select';
+import { selectProjectConversations, useChatStore } from './store.js';
+import { CounterClockwiseClockIcon, PlusIcon } from '../icons.js';
+import { Select } from '../primitives/Select.js';
 
 export function ConversationSelect(): JSX.Element {
   const conversations = useChatStore(selectProjectConversations);
@@ -20,7 +20,7 @@ export function ConversationSelect(): JSX.Element {
       items={[
         ...conversations.map(([conversationId, { messages }]) => ({
           value: conversationId,
-          label: messages[0].content,
+          label: messages[0]?.content,
         })),
         {
           value: 'new',

--- a/packages/react/src/chat/ConversationSidebar.tsx
+++ b/packages/react/src/chat/ConversationSidebar.tsx
@@ -1,6 +1,6 @@
-import { selectProjectConversations, useChatStore } from './store';
-import { PlusIcon } from '../icons';
-import { markdownToString } from '../utils';
+import { selectProjectConversations, useChatStore } from './store.js';
+import { PlusIcon } from '../icons.js';
+import { markdownToString } from '../utils.js';
 
 export function ConversationSidebar(): JSX.Element {
   const selectedConversationId = useChatStore((state) => state.conversationId);

--- a/packages/react/src/chat/DefaultToolCallsConfirmation.tsx
+++ b/packages/react/src/chat/DefaultToolCallsConfirmation.tsx
@@ -2,13 +2,13 @@ import { type ChatCompletionMessageToolCall } from '@markprompt/core';
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon';
 import { useCallback, useMemo } from 'react';
 
-import { type ChatViewTool, type ToolCall } from './store';
+import { type ChatViewTool, type ToolCall } from './store.js';
 import {
   CheckCircleIcon,
   CircleDashedIcon,
   CrossCircleIcon,
   LoaderIcon,
-} from '../icons';
+} from '../icons.js';
 
 interface DefaultToolCallsConfirmationProps {
   toolCalls: ChatCompletionMessageToolCall[];

--- a/packages/react/src/chat/DefaultView.tsx
+++ b/packages/react/src/chat/DefaultView.tsx
@@ -1,6 +1,6 @@
 import { type ComponentType, type ReactElement } from 'react';
 
-import type { DefaultViewProps } from '../types';
+import type { DefaultViewProps } from '../types.js';
 
 export function DefaultMessage(props: {
   message: string | ComponentType;

--- a/packages/react/src/chat/MessageAnswer.tsx
+++ b/packages/react/src/chat/MessageAnswer.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
 
-import { Answer } from './Answer';
-import { type ChatViewMessage } from './store';
+import { Answer } from './Answer.js';
+import { type ChatViewMessage } from './store.js';
 
 interface MessageAnswerProps {
   children: string;

--- a/packages/react/src/chat/MessagePrompt.tsx
+++ b/packages/react/src/chat/MessagePrompt.tsx
@@ -1,8 +1,8 @@
 import { type ReactElement } from 'react';
 
-import { type ChatViewMessage } from './store';
-import { UserIcon } from '../icons';
-import type { MarkpromptOptions } from '../types';
+import { type ChatViewMessage } from './store.js';
+import { UserIcon } from '../icons.js';
+import type { MarkpromptOptions } from '../types.js';
 
 interface MessagePromptProps {
   children: string;

--- a/packages/react/src/chat/Messages.tsx
+++ b/packages/react/src/chat/Messages.tsx
@@ -1,12 +1,12 @@
 import { type ReactElement } from 'react';
 
-import { AssistantMessage } from './AssistantMessage';
-import { DefaultView } from './DefaultView';
-import { MessagePrompt } from './MessagePrompt';
-import { References } from './References';
-import { useChatStore } from './store';
-import * as BaseMarkprompt from '../primitives/headless';
-import type { MarkpromptOptions } from '../types';
+import { AssistantMessage } from './AssistantMessage.js';
+import { DefaultView } from './DefaultView.js';
+import { MessagePrompt } from './MessagePrompt.js';
+import { References } from './References.js';
+import { useChatStore } from './store.js';
+import * as BaseMarkprompt from '../primitives/headless.js';
+import type { MarkpromptOptions } from '../types.js';
 
 interface MessagesProps {
   chatOptions: NonNullable<MarkpromptOptions['chat']>;

--- a/packages/react/src/chat/References.tsx
+++ b/packages/react/src/chat/References.tsx
@@ -1,9 +1,9 @@
 import type { FileSectionReference } from '@markprompt/core';
 import { useCallback, useMemo, type ReactElement } from 'react';
 
-import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants';
-import type { ChatLoadingState } from '../index';
-import * as Markprompt from '../primitives/headless';
+import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants.js';
+import type { ChatLoadingState } from '../index.js';
+import * as Markprompt from '../primitives/headless.js';
 
 interface ReferenceProps {
   getHref?: (reference: FileSectionReference) => string | undefined;

--- a/packages/react/src/chat/RegenerateButton.tsx
+++ b/packages/react/src/chat/RegenerateButton.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, useCallback } from 'react';
 
-import type { ChatViewMessage } from './store';
-import { ReloadIcon, StopIcon } from '../icons';
+import type { ChatViewMessage } from './store.js';
+import { ReloadIcon, StopIcon } from '../icons.js';
 
 interface RegenerateButtonProps {
   abortSubmitChat?: () => void;

--- a/packages/react/src/chat/store.tsx
+++ b/packages/react/src/chat/store.tsx
@@ -22,8 +22,13 @@ import { createStore, useStore } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 
-import type { MarkpromptOptions } from '../types';
-import { hasValueAtKey, isIterable, isPresent, isStoredError } from '../utils';
+import type { MarkpromptOptions } from '../types.js';
+import {
+  hasValueAtKey,
+  isIterable,
+  isPresent,
+  isStoredError,
+} from '../utils.js';
 
 export type ChatLoadingState =
   | 'indeterminate'

--- a/packages/react/src/constants.test.ts
+++ b/packages/react/src/constants.test.ts
@@ -5,7 +5,7 @@ import type {
 } from '@markprompt/core';
 import { describe, expect, test } from 'vitest';
 
-import { DEFAULT_MARKPROMPT_OPTIONS } from './constants';
+import { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
 
 const basePath = '/docs/guides';
 const filePath = `${basePath}/index.md`;
@@ -93,80 +93,80 @@ const algoliaSearchHits = [
 
 describe('constants', () => {
   test('default references.getHref', async () => {
-    expect(DEFAULT_MARKPROMPT_OPTIONS.references!.getHref?.(results[0])).toBe(
+    expect(DEFAULT_MARKPROMPT_OPTIONS.references!.getHref?.(results[0]!)).toBe(
       `${basePath}#${headingSlug}`,
     );
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.references!.getHref?.(results[1]),
+      DEFAULT_MARKPROMPT_OPTIONS.references!.getHref?.(results[1]!),
     ).toEqual(basePath);
   });
 
   test('default references.getLabel', async () => {
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[0]),
+      DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[0]!),
     ).toEqual(heading);
-    expect(DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[1])).toBe(
+    expect(DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[1]!)).toBe(
       'Home',
     );
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[2]),
+      DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[2]!),
     ).toEqual(noTitleFileName);
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[3]),
+      DEFAULT_MARKPROMPT_OPTIONS.references!.getLabel?.(results[3]!),
     ).toEqual(noTitleFileName);
   });
 
   test('default search.getHref', async () => {
-    expect(DEFAULT_MARKPROMPT_OPTIONS.search!.getHref?.(results[0])).toBe(
+    expect(DEFAULT_MARKPROMPT_OPTIONS.search!.getHref?.(results[0]!)).toBe(
       `${basePath}#${headingSlug}`,
     );
-    expect(DEFAULT_MARKPROMPT_OPTIONS.search!.getHref?.(results[6])).toBe(
+    expect(DEFAULT_MARKPROMPT_OPTIONS.search!.getHref?.(results[6]!)).toBe(
       `${basePath}#${headingId}`,
     );
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getHref?.(algoliaSearchHits[0]),
-    ).toEqual(algoliaSearchHits[0].url);
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getHref?.(algoliaSearchHits[0]!),
+    ).toEqual(algoliaSearchHits[0]!.url);
   });
 
   test('default search.getHeading', async () => {
-    expect(DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(results[0])).toEqual(
-      results[0].file.title,
-    );
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(results[1]),
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(results[0]!),
+    ).toEqual(results[0]!.file.title);
+    expect(
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(results[1]!),
     ).toBeUndefined();
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(algoliaSearchHits[0]),
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(algoliaSearchHits[0]!),
     ).toBeUndefined();
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(algoliaSearchHits[1]),
-    ).toEqual(algoliaSearchHits[1].hierarchy.lvl0);
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getHeading?.(algoliaSearchHits[1]!),
+    ).toEqual(algoliaSearchHits[1]!.hierarchy.lvl0);
   });
 
   test('default search.getTitle', async () => {
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[0], ''),
-    ).toEqual(results[0].meta?.leadHeading?.value);
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[0]!, ''),
+    ).toEqual(results[0]!.meta?.leadHeading?.value);
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[1], ''),
-    ).toEqual(results[1].file.title);
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[1]!, ''),
+    ).toEqual(results[1]!.file.title);
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[4], 'aute'),
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[4]!, 'aute'),
     ).toEqual(loremIpsumKwicSnippet);
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[5], 'Some'),
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(results[5]!, 'Some'),
     ).toEqual(shortContent);
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(algoliaSearchHits[0], ''),
-    ).toEqual(algoliaSearchHits[0].hierarchy.lvl1);
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getTitle?.(algoliaSearchHits[0]!, ''),
+    ).toEqual(algoliaSearchHits[0]!.hierarchy.lvl1);
   });
 
   test('default search.getSubtitle', async () => {
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getSubtitle?.(results[0]),
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getSubtitle?.(results[0]!),
     ).toBeUndefined();
     expect(
-      DEFAULT_MARKPROMPT_OPTIONS.search!.getSubtitle?.(algoliaSearchHits[0]),
-    ).toEqual(algoliaSearchHits[0].hierarchy.lvl2);
+      DEFAULT_MARKPROMPT_OPTIONS.search!.getSubtitle?.(algoliaSearchHits[0]!),
+    ).toEqual(algoliaSearchHits[0]!.hierarchy.lvl2);
   });
 });

--- a/packages/react/src/constants.tsx
+++ b/packages/react/src/constants.tsx
@@ -4,7 +4,7 @@ import {
   type SearchResult,
 } from '@markprompt/core';
 
-import type { MarkpromptOptions } from './types';
+import type { MarkpromptOptions } from './types.js';
 
 const removeFileExtension = (fileName: string): string => {
   const lastDotIndex = fileName.lastIndexOf('.');

--- a/packages/react/src/feedback/Feedback.test.tsx
+++ b/packages/react/src/feedback/Feedback.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { Feedback } from './Feedback';
+import { Feedback } from './Feedback.js';
 
 describe('Feedback', () => {
   const submitFeedback = vi.fn(() => Promise.resolve());

--- a/packages/react/src/feedback/Feedback.tsx
+++ b/packages/react/src/feedback/Feedback.tsx
@@ -7,10 +7,10 @@ import {
   useEffect,
 } from 'react';
 
-import type { UseFeedbackResult } from './useFeedback';
-import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants';
-import { ThumbsDownIcon, ThumbsUpIcon } from '../icons';
-import { CopyContentButton } from '../primitives/headless';
+import type { UseFeedbackResult } from './useFeedback.js';
+import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants.js';
+import { ThumbsDownIcon, ThumbsUpIcon } from '../icons.js';
+import { CopyContentButton } from '../primitives/headless.js';
 
 interface FeedbackProps extends ComponentPropsWithoutRef<'aside'> {
   message?: string;

--- a/packages/react/src/feedback/useFeedback.test.ts
+++ b/packages/react/src/feedback/useFeedback.test.ts
@@ -4,7 +4,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { useFeedback } from './useFeedback';
+import { useFeedback } from './useFeedback.js';
 
 let status = 200;
 let endpointHits = 0;

--- a/packages/react/src/feedback/useFeedback.ts
+++ b/packages/react/src/feedback/useFeedback.ts
@@ -6,7 +6,7 @@ import {
 } from '@markprompt/core';
 import { useCallback } from 'react';
 
-import { useAbortController } from '../useAbortController';
+import { useAbortController } from '../useAbortController.js';
 
 export interface UseFeedbackOptions {
   /** Enable and configure feedback functionality */

--- a/packages/react/src/icons.test.tsx
+++ b/packages/react/src/icons.test.tsx
@@ -20,7 +20,7 @@ import {
   ThumbsDownIcon,
   ThumbsUpIcon,
   PlusIcon,
-} from './icons';
+} from './icons.js';
 
 const icons = [
   ChatIcon,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,29 +30,29 @@ export {
   type SearchResultProps,
   type SearchResultsProps,
   type TitleProps,
-} from './primitives/headless';
+} from './primitives/headless.js';
 
 export {
   useFeedback,
   type UseFeedbackOptions,
   type UseFeedbackResult,
-} from './feedback/useFeedback';
+} from './feedback/useFeedback.js';
 
 export {
   useSearch,
   type SearchLoadingState,
   type UseSearchOptions,
   type UseSearchResult,
-} from './search/useSearch';
+} from './search/useSearch.js';
 
 export {
   Markprompt,
   type MarkpromptProps,
   openMarkprompt,
   closeMarkprompt,
-} from './Markprompt';
+} from './Markprompt.js';
 
-export { ChatView, type ChatViewProps } from './chat/ChatView';
+export { ChatView, type ChatViewProps } from './chat/ChatView.js';
 export {
   ChatProvider,
   useChatStore,
@@ -63,9 +63,9 @@ export {
   type ConfirmationProps,
   type ToolCall,
   type ChatViewTool,
-} from './chat/store';
-export { SearchView, type SearchViewProps } from './search/SearchView';
+} from './chat/store.js';
+export { SearchView, type SearchViewProps } from './search/SearchView.js';
 
-export { DEFAULT_MARKPROMPT_OPTIONS } from './constants';
+export { DEFAULT_MARKPROMPT_OPTIONS } from './constants.js';
 
-export * from './types';
+export * from './types.js';

--- a/packages/react/src/primitives/ConditionalWrap.test.tsx
+++ b/packages/react/src/primitives/ConditionalWrap.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { ConditionalVisuallyHidden, ConditionalWrap } from './ConditionalWrap';
+import {
+  ConditionalVisuallyHidden,
+  ConditionalWrap,
+} from './ConditionalWrap.js';
 
 describe('ConditionalWrap', () => {
   it('renders', () => {

--- a/packages/react/src/primitives/footer.test.tsx
+++ b/packages/react/src/primitives/footer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 
-import { Footer, MarkpromptIcon } from './footer';
+import { Footer, MarkpromptIcon } from './footer.js';
 
 describe('Footer', () => {
   test('render a footer', () => {

--- a/packages/react/src/primitives/headless.test.tsx
+++ b/packages/react/src/primitives/headless.test.tsx
@@ -16,7 +16,7 @@ import {
   vitest,
 } from 'vitest';
 
-import * as Markprompt from './headless';
+import * as Markprompt from './headless.js';
 
 let searchResults: SearchResult[] = [];
 let status = 200;

--- a/packages/react/src/primitives/headless.tsx
+++ b/packages/react/src/primitives/headless.tsx
@@ -18,16 +18,16 @@ import Markdown from 'react-markdown';
 import { mergeRefs } from 'react-merge-refs';
 import remarkGfm from 'remark-gfm';
 
-import { ConditionalVisuallyHidden } from './ConditionalWrap';
-import { Footer } from './footer';
-import { CheckIcon, ClipboardIcon } from '../icons';
-import type { ChatLoadingState } from '../index';
+import { ConditionalVisuallyHidden } from './ConditionalWrap.js';
+import { Footer } from './footer.js';
+import { CheckIcon, ClipboardIcon } from '../icons.js';
+import type { ChatLoadingState } from '../index.js';
 import type {
   MarkpromptOptions,
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
   SearchResultComponentProps,
-} from '../types';
+} from '../types.js';
 
 type RootProps = Dialog.DialogProps & { display?: 'plain' | 'dialog' };
 

--- a/packages/react/src/search/SearchBoxTrigger.tsx
+++ b/packages/react/src/search/SearchBoxTrigger.tsx
@@ -11,9 +11,9 @@ import {
   CommandIcon,
   CornerDownLeftIcon,
   SearchIcon,
-} from '../icons';
-import * as BaseMarkprompt from '../primitives/headless';
-import { type MarkpromptOptions } from '../types';
+} from '../icons.js';
+import * as BaseMarkprompt from '../primitives/headless.js';
+import { type MarkpromptOptions } from '../types.js';
 
 interface SearchBoxTriggerProps {
   trigger: MarkpromptOptions['trigger'];

--- a/packages/react/src/search/SearchResult.tsx
+++ b/packages/react/src/search/SearchResult.tsx
@@ -1,7 +1,7 @@
 import { Fragment, forwardRef, memo, type ComponentType } from 'react';
 
-import { FileTextIcon, HashIcon } from '../icons';
-import { type SearchResultProps as BaseSearchResultProps } from '../index';
+import { FileTextIcon, HashIcon } from '../icons.js';
+import { type SearchResultProps as BaseSearchResultProps } from '../index.js';
 
 interface HighlightMatchesProps {
   value?: string;

--- a/packages/react/src/search/SearchView.test.tsx
+++ b/packages/react/src/search/SearchView.test.tsx
@@ -17,7 +17,7 @@ import {
   vi,
 } from 'vitest';
 
-import { SearchView } from './SearchView';
+import { SearchView } from './SearchView.js';
 
 let status = 200;
 let results: SearchResult[] | AlgoliaDocSearchHit[] = [];

--- a/packages/react/src/search/SearchView.tsx
+++ b/packages/react/src/search/SearchView.tsx
@@ -13,17 +13,17 @@ import {
   useMemo,
 } from 'react';
 
-import { SearchResult } from './SearchResult';
-import { useSearch, type SearchLoadingState } from './useSearch';
-import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants';
-import { ChevronRightIcon, SearchIcon, SparklesIcon } from '../icons';
-import * as BaseMarkprompt from '../primitives/headless';
+import { SearchResult } from './SearchResult.js';
+import { useSearch, type SearchLoadingState } from './useSearch.js';
+import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants.js';
+import { ChevronRightIcon, SearchIcon, SparklesIcon } from '../icons.js';
+import * as BaseMarkprompt from '../primitives/headless.js';
 import {
   type MarkpromptOptions,
   type SearchResultComponentProps,
   type View,
-} from '../types';
-import { useDefaults } from '../useDefaults';
+} from '../types.js';
+import { useDefaults } from '../useDefaults.js';
 
 export interface SearchViewProps {
   activeView?: View;

--- a/packages/react/src/search/useSearch.test.ts
+++ b/packages/react/src/search/useSearch.test.ts
@@ -16,7 +16,7 @@ import {
   vi,
 } from 'vitest';
 
-import { type UseSearchResult, useSearch } from './useSearch';
+import { type UseSearchResult, useSearch } from './useSearch.js';
 
 let searchResults: SearchResult[] | AlgoliaDocSearchHit[] = [];
 let status = 200;
@@ -128,16 +128,16 @@ describe('useSearch', () => {
     await waitFor(() => expect(searchHits).toBe(1));
 
     expect(result.current.searchResults[0]?.href).toBe(
-      (searchResults as SearchResult[])[0].file.path,
+      (searchResults as SearchResult[])[0]?.file.path,
     );
     expect(result.current.searchResults[0]?.title).toBe(
-      (searchResults as SearchResult[])[0].file.title,
+      (searchResults as SearchResult[])[0]?.file.title,
     );
     expect(result.current.searchResults[1]?.title).toBe(
-      (searchResults as SearchResult[])[1].meta?.leadHeading?.value,
+      (searchResults as SearchResult[])[1]?.meta?.leadHeading?.value,
     );
     expect(result.current.searchResults[2]?.title).toBe(
-      (searchResults as SearchResult[])[2].snippet,
+      (searchResults as SearchResult[])[2]?.snippet,
     );
   });
 

--- a/packages/react/src/search/useSearch.ts
+++ b/packages/react/src/search/useSearch.ts
@@ -11,9 +11,12 @@ import {
 import debounce from 'p-debounce';
 import { useCallback, useState } from 'react';
 
-import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants';
-import type { MarkpromptOptions, SearchResultComponentProps } from '../types';
-import { useAbortController } from '../useAbortController';
+import { DEFAULT_MARKPROMPT_OPTIONS } from '../constants.js';
+import type {
+  MarkpromptOptions,
+  SearchResultComponentProps,
+} from '../types.js';
+import { useAbortController } from '../useAbortController.js';
 
 export type SearchLoadingState = 'indeterminate' | 'preload' | 'done';
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -15,8 +15,8 @@ import type {
   ReactNode,
 } from 'react';
 
-import type { UserConfigurableOptions } from './chat/store';
-import type { ChatViewMessage } from './index';
+import type { UserConfigurableOptions } from './chat/store.js';
+import type { ChatViewMessage } from './index.js';
 
 export type View = 'chat' | 'search';
 

--- a/packages/react/src/useDefaults.test.tsx
+++ b/packages/react/src/useDefaults.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { cloneElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useDefaults } from './useDefaults';
+import { useDefaults } from './useDefaults.js';
 
 vi.mock('react', async (importOriginal) => {
   const mod = await importOriginal<typeof import('react')>();

--- a/packages/react/src/useDefaults.ts
+++ b/packages/react/src/useDefaults.ts
@@ -1,5 +1,5 @@
-import cloneDeepWith from 'lodash/cloneDeepWith';
-import defaults from 'lodash/defaultsDeep';
+import cloneDeepWith from 'lodash/cloneDeepWith.js';
+import defaults from 'lodash/defaultsDeep.js';
 import { cloneElement, isValidElement, useMemo } from 'react';
 
 type DeepMerge<T, U> = T extends { [key: string]: unknown }

--- a/packages/react/src/useViews.ts
+++ b/packages/react/src/useViews.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import type { MarkpromptOptions, View } from './types';
+import type { MarkpromptOptions, View } from './types.js';
 
 interface UseViewsResult {
   activeView: View;

--- a/packages/react/src/utils.test.ts
+++ b/packages/react/src/utils.test.ts
@@ -6,7 +6,7 @@ import {
   isIterable,
   hasPresentKey,
   hasValueAtKey,
-} from './utils';
+} from './utils.js';
 
 describe('utils', () => {
   test('isIterable', () => {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,21 +2,30 @@
   "references": [{ "path": "../core" }],
   "include": ["src/"],
   "compilerOptions": {
-    "lib": ["dom", "es2022", "esnext"],
-    "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
+    // base
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+
+    // strictness
+    "strict": true,
+
+    // transpilation
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "rootDir": "./src",
-    "strict": true,
+    "composite": true,
     "jsx": "react-jsx",
-    "outDir": "dist",
-    "skipLibCheck": true,
-    "target": "es2021",
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
+
+    // runtime
+    "lib": ["dom", "dom.iterable", "es2023"],
+
     "types": ["@testing-library/jest-dom/vitest"],
     "paths": {
       "@markprompt/core": ["../core/src"],

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -22,6 +22,7 @@
     "declarationMap": true,
     "composite": true,
     "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
 
     // runtime
     "lib": ["dom", "dom.iterable", "es2023"],

--- a/packages/web/scripts/config.js
+++ b/packages/web/scripts/config.js
@@ -8,7 +8,7 @@ const config = {
   entryPoints: ['src/index.tsx', 'src/init.ts'],
   outdir: 'dist/',
   format: 'esm',
-  target: '',
+  target: 'esnext',
   bundle: true,
   treeShaking: true,
   sourcemap: true,

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -21,14 +21,15 @@
     // transpilation
     "module": "esnext",
     "moduleResolution": "bundler",
-    "noEmit": true,
     "outDir": "dist/",
     "rootDir": "src/",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "composite": true,
     "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
 
     // runtime
     "lib": ["dom", "dom.iterable", "es2023"],

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -6,23 +6,33 @@
   ],
   "include": ["src/*"],
   "compilerOptions": {
+    // base
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "allowJs": true,
     "checkJs": true,
+
+    // strictness
+    "strict": true,
+
+    // transpilation
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "esnext",
+    "noEmit": true,
+    "outDir": "dist/",
+    "rootDir": "src/",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "incremental": true,
-    "emitDeclarationOnly": true,
     "composite": true,
-    "strict": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
     "jsx": "react-jsx",
-    "outDir": "dist/",
-    "rootDir": "./src",
+
+    // runtime
+    "lib": ["dom", "dom.iterable", "es2023"],
+
     "paths": {
       "react": ["./node_modules/preact/compat"],
       "react-dom": ["./node_modules/preact/compat"],


### PR DESCRIPTION
`moduleResolution: bundler` should only be used if `tsc` is not used to generate files. We do use it for that reason, so I wrongly updated the `tsconfig` files in the previous release. 

There should not be any user impact of this change, but this config is actually correct.