### PR TITLE
Add custom fields support for create ticket view

### DIFF
--- a/.changeset/angry-coins-chew.md
+++ b/.changeset/angry-coins-chew.md
@@ -1,0 +1,8 @@
+---
+"@markprompt/react": minor
+"@markprompt/css": minor
+"@markprompt/docusaurus-theme-search": minor
+"@markprompt/web": minor
+---
+
+Add custom fields support for create ticket view

--- a/examples/with-markprompt-web/src/main.ts
+++ b/examples/with-markprompt-web/src/main.ts
@@ -37,6 +37,53 @@ if (el && el instanceof HTMLElement) {
         },
         form: {
           hasFileUploadInput: true,
+          emailLabel: 'Email',
+          nameLabel: 'Name',
+          emailPlaceholder: 'jane@doe.com',
+          namePlaceholder: 'Jane Doe',
+          maxFileSizeError: 'File size should be less than 4.5MB',
+          submitLabel: 'Submit case',
+          summaryLabel: 'Summary',
+          summaryLoading: 'Generating summary…',
+          summaryPlaceholder: 'Please describe your issue',
+          ticketCreatedError: 'An error occurred while creating the case',
+          ticketCreatedOk: 'Thank you! We will get back to you shortly.',
+          uploadFileLabel: 'Attach files (optional)',
+          customFields: [
+            {
+              id: '12345678',
+              label: 'Case type',
+              items: [
+                { value: 'Bug', label: 'Bug' },
+                { value: 'Feature request', label: 'Feature request' },
+                { value: 'Other', label: 'Other' },
+              ],
+            },
+            {
+              id: '87654321',
+              label: 'Category',
+              items: [
+                {
+                  label: 'Legal',
+                  items: [
+                    { value: 'Contract', label: 'Contract' },
+                    { value: 'Compliance', label: 'Compliance' },
+                  ],
+                },
+                {
+                  label: 'Account & Billing',
+                  items: [
+                    { value: 'Payment', label: 'Payment' },
+                    { value: 'Invoice', label: 'Invoice' },
+                  ],
+                },
+                {
+                  value: 'Other',
+                  label: 'Other',
+                },
+              ],
+            },
+          ],
         },
       },
     },

--- a/packages/css/markprompt.css
+++ b/packages/css/markprompt.css
@@ -2091,6 +2091,15 @@
   background-color: var(--markprompt-muted);
 }
 
+.MarkpromptSelectToggleWithIcon {
+  min-width: 8rem;
+  justify-content: space-between;
+}
+
+.MarkpromptSelectToggleMuted {
+  color: var(--markprompt-mutedForeground);
+}
+
 .MarkpromptSelectMenu {
   display: none;
   background-color: var(--markprompt-background);
@@ -2105,6 +2114,7 @@
     var(--markprompt-ring-shadow, 0 0 #0000), var(--markprompt-shadow);
   max-width: 30ch;
   overflow: hidden;
+  will-change: auto;
 }
 
 .MarkpromptSelectMenu[data-open='true'] {
@@ -2133,6 +2143,19 @@
 
 .MarkpromptSelectMenu li[data-selected='true'] {
   font-weight: 600;
+}
+
+.MarkpromptSelectMenu ul {
+  padding-left: 0;
+}
+
+.MarkpromptSelectMenu li:has(.MarkpromptSelectGroupLabel) {
+  padding-bottom: 0;
+}
+
+.MarkpromptSelectGroupLabel {
+  display: flex;
+  margin-block-end: 0.25rem;
 }
 
 .MarkpromptNewChatOption {
@@ -2563,28 +2586,44 @@
   border-color: var(--markprompt-border-accent);
 }
 
-.MarkpromptCreateTicketForm :nth-child(1) {
+.MarkpromptCreateTicketForm > *:nth-child(1) {
   --form-group-index: 1;
 }
 
-.MarkpromptCreateTicketForm :nth-child(2) {
+.MarkpromptCreateTicketForm > *:nth-child(2) {
   --form-group-index: 2;
 }
 
-.MarkpromptCreateTicketForm :nth-child(3) {
+.MarkpromptCreateTicketForm > *:nth-child(3) {
   --form-group-index: 3;
 }
 
-.MarkpromptCreateTicketForm :nth-child(4) {
+.MarkpromptCreateTicketForm > *:nth-child(4) {
   --form-group-index: 4;
 }
 
-.MarkpromptCreateTicketForm :nth-child(5) {
+.MarkpromptCreateTicketForm > *:nth-child(5) {
   --form-group-index: 5;
 }
 
-.MarkpromptCreateTicketForm :nth-child(6) {
+.MarkpromptCreateTicketForm > *:nth-child(6) {
   --form-group-index: 6;
+}
+
+.MarkpromptCreateTicketForm > *:nth-child(7) {
+  --form-group-index: 7;
+}
+
+.MarkpromptCreateTicketForm > *:nth-child(8) {
+  --form-group-index: 8;
+}
+
+.MarkpromptCreateTicketForm > *:nth-child(9) {
+  --form-group-index: 9;
+}
+
+.MarkpromptCreateTicketForm > *:nth-child(10) {
+  --form-group-index: 10;
 }
 
 .MarkpromptCreateTicketForm > div {
@@ -3051,9 +3090,13 @@
     transform: translateY(10px);
   }
 
-  100% {
+  99% {
     opacity: 1;
     transform: translateY(0);
+  }
+
+  100% {
+    transform: unset;
   }
 }
 

--- a/packages/react/src/chat/ConversationSelect.tsx
+++ b/packages/react/src/chat/ConversationSelect.tsx
@@ -25,7 +25,7 @@ export function ConversationSelect({
       items={[
         ...conversations.map(([conversationId, { messages }]) => ({
           value: conversationId,
-          label: messages[0]?.content,
+          label: messages[0]?.content ?? '',
         })),
         {
           value: 'new',

--- a/packages/react/src/primitives/Select.tsx
+++ b/packages/react/src/primitives/Select.tsx
@@ -8,34 +8,27 @@ import {
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import clsx from 'clsx';
 import { useSelect, type UseSelectProps } from 'downshift';
-import { useMemo, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 interface Option {
   value: string;
   label: string;
 }
 
-interface OptGroup<T extends Option> {
-  label: string;
-  items: T[];
-}
-
-interface SelectProps<T extends Option>
-  extends Omit<UseSelectProps<T>, 'items'> {
+interface SelectProps<T = Option> extends UseSelectProps<T> {
   className?: string;
-  disabled?: boolean;
-  hasLabel?: boolean;
-  itemClassName?: string;
-  items: (OptGroup<T> | T)[];
+  items: T[];
   itemToChildren?: (item: T | null) => ReactNode;
   itemToString: (item: T | null) => string;
   label?: ReactNode;
-  menuClassName?: string;
   toggle?: ReactNode;
+  menuClassName?: string;
   toggleClassName?: string;
+  itemClassName?: string;
+  disabled?: boolean;
 }
 
-export function Select<T extends Option>(props: SelectProps<T>): JSX.Element {
+export function Select<T = Option>(props: SelectProps<T>): JSX.Element {
   const {
     className,
     itemClassName,
@@ -47,14 +40,8 @@ export function Select<T extends Option>(props: SelectProps<T>): JSX.Element {
     itemToChildren,
     itemToString,
     disabled,
-    hasLabel,
     ...useSelectProps
   } = props;
-
-  const flatItems = useMemo(
-    () => items.flatMap((x) => ('items' in x ? x.items : [x])),
-    [items],
-  );
 
   const {
     getItemProps,
@@ -65,7 +52,7 @@ export function Select<T extends Option>(props: SelectProps<T>): JSX.Element {
     isOpen,
     selectedItem,
   } = useSelect({
-    items: flatItems,
+    items,
     itemToString,
     ...useSelectProps,
   });
@@ -77,11 +64,11 @@ export function Select<T extends Option>(props: SelectProps<T>): JSX.Element {
     placement: 'top-start',
   });
 
-  const labelEl = <label {...getLabelProps()}>{label}</label>;
-
   return (
     <div className={clsx('MarkpromptSelect', className)}>
-      {hasLabel ? labelEl : <VisuallyHidden asChild>{labelEl}</VisuallyHidden>}
+      <VisuallyHidden asChild>
+        <label {...getLabelProps()}>{label}</label>
+      </VisuallyHidden>
 
       <button
         type="button"
@@ -99,94 +86,18 @@ export function Select<T extends Option>(props: SelectProps<T>): JSX.Element {
         {...getMenuProps({ ref: refs.setFloating })}
       >
         {isOpen &&
-          items.map((itemOrGroup, index) =>
-            'items' in itemOrGroup ? (
-              <li key={itemOrGroup.label}>
-                <b>{itemOrGroup.label}</b>
-                <ul>
-                  {itemOrGroup.items.map((item) => (
-                    <li
-                      key={itemToString(item)}
-                      className={itemClassName}
-                      data-highlighted={highlightedIndex === index}
-                      data-selected={
-                        itemToString(selectedItem) === itemToString(item)
-                      }
-                      {...getItemProps({ item, index })}
-                    >
-                      {itemToChildren
-                        ? itemToChildren(item)
-                        : itemToString(item)}
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            ) : (
-              <li
-                key={`${itemToString(itemOrGroup)}`}
-                // itemIndex={flatItems.findIndex(
-                //   (x) => itemToString(x) === itemToString(itemOrGroup),
-                // )}
-                className={itemClassName}
-                data-highlighted={
-                  highlightedIndex ===
-                  flatItems.findIndex(
-                    (x) => itemToString(x) === itemToString(itemOrGroup),
-                  )
-                }
-                data-selected={
-                  itemToString(selectedItem) === itemToString(itemOrGroup)
-                }
-                {...getItemProps({
-                  item: itemOrGroup,
-                  index: flatItems.findIndex(
-                    (x) => itemToString(x) === itemToString(itemOrGroup),
-                  ),
-                })}
-              >
-                {itemToChildren
-                  ? itemToChildren(itemOrGroup)
-                  : itemToString(itemOrGroup)}
-              </li>
-            ),
-          )}
+          items.map((item, index) => (
+            <li
+              key={`${itemToString(item)}-${index}`}
+              className={itemClassName}
+              data-highlighted={highlightedIndex === index}
+              data-selected={itemToString(selectedItem) === itemToString(item)}
+              {...getItemProps({ item, index })}
+            >
+              {itemToChildren ? itemToChildren(item) : itemToString(item)}
+            </li>
+          ))}
       </ul>
     </div>
   );
 }
-
-// export interface OptionsProps<T extends Option> {
-//   items: T[];
-//   itemClassName?: string;
-//   itemIndex: number;
-//   highlightedIndex: number;
-//   itemToString: (item: T) => string;
-//   selectedItem: T;
-//   itemToChildren?: (item: T | null) => ReactNode;
-//   getItemProps: UseSelectReturnValue<T>['getItemProps'];
-// }
-
-// function Options<T extends Option>(props: OptionsProps<T>) {
-//   const {
-//     items,
-//     itemIndex,
-//     itemClassName,
-//     highlightedIndex,
-//     itemToString,
-//     selectedItem,
-//     itemToChildren,
-//     getItemProps,
-//   } = props;
-
-//   return items.map((item) => (
-//     <li
-//       key={`${itemToString(item)}-${itemIndex}`}
-//       className={itemClassName}
-//       data-highlighted={highlightedIndex === itemIndex}
-//       data-selected={itemToString(selectedItem) === itemToString(item)}
-//       {...getItemProps({ item, index: itemIndex })}
-//     >
-//       {itemToChildren ? itemToChildren(item) : itemToString(item)}
-//     </li>
-//   ));
-// }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -518,6 +518,44 @@ export interface CreateTicketIntegrationMessageButtonOptions {
   hasText?: boolean;
 }
 
+export interface CustomFieldOption {
+  /**
+   * The displayed label for this custom field option
+   */
+  label: string;
+  /**
+   * The value of the custom field that will be sent to the service provider
+   */
+  value: string;
+}
+
+export interface CustomFieldOptionGroup {
+  /**
+   * Options group label
+   */
+  label: string;
+
+  /**
+   * Grouped options
+   */
+  items: CustomFieldOption[];
+}
+
+export interface CustomField {
+  /**
+   * The displayed label for this custom field
+   */
+  label: string;
+  /**
+   * The custom field id.
+   */
+  id: string;
+  /**
+   * Options for this custom field
+   */
+  items: (CustomFieldOptionGroup | CustomFieldOption)[];
+}
+
 export interface CreateTicketIntegrationFormOptions {
   /**
    * Label for the name input
@@ -582,6 +620,12 @@ export interface CreateTicketIntegrationFormOptions {
    * @default "Total file size is too large to upload. Maximum allowed size is 4.5MB."
    */
   maxFileSizeError: string;
+  /**
+   * Custom fields
+   * @see https://developer.zendesk.com/documentation/ticketing/managing-tickets/creating-and-updating-tickets/#setting-custom-field-values
+   * @default undefined;
+   */
+  customFields?: CustomField[];
 }
 
 export interface CreateTicketIntegrationUserOptions {
@@ -602,7 +646,7 @@ export interface CreateTicketIntegrationOptions {
    **/
   enabled: boolean;
   /**
-   * The provider to use for creating tickets
+   * The provider to use for creating tickets.
    **/
   provider: 'zendesk';
   /**


### PR DESCRIPTION
- Allows users to select custom fields as defined by the implementer. Custom fields are sent on to the provider, currently Zendesk is supported. Custom field id should correspond to the id of a custom field in Zendesk.